### PR TITLE
feat: Add Public Events API and Core Data Models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ Homestead.yaml
 Thumbs.db
 PRD.md
 progress.txt
+brief.md
+plans

--- a/app/Enums/CustomFieldType.php
+++ b/app/Enums/CustomFieldType.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Enums;
+
+enum CustomFieldType: string
+{
+    case Text = 'text';
+    case Number = 'number';
+    case Select = 'select';
+    case Checkbox = 'checkbox';
+    case Textarea = 'textarea';
+}

--- a/app/Enums/EventStatus.php
+++ b/app/Enums/EventStatus.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Enums;
+
+enum EventStatus: string
+{
+    case Draft = 'draft';
+    case Published = 'published';
+    case Active = 'active';
+    case Completed = 'completed';
+    case Cancelled = 'cancelled';
+
+    public function isPubliclyVisible(): bool
+    {
+        return match ($this) {
+            self::Published, self::Active, self::Completed => true,
+            self::Draft, self::Cancelled => false,
+        };
+    }
+
+    public function hasRoundsVisible(): bool
+    {
+        return match ($this) {
+            self::Active, self::Completed => true,
+            self::Draft, self::Published, self::Cancelled => false,
+        };
+    }
+}

--- a/app/Enums/PairingFormat.php
+++ b/app/Enums/PairingFormat.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enums;
+
+enum PairingFormat: string
+{
+    case Swiss = 'swiss';
+    case RoundRobin = 'round_robin';
+    case Knockout = 'knockout';
+    case Random = 'random';
+}

--- a/app/Enums/RoundStatus.php
+++ b/app/Enums/RoundStatus.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum RoundStatus: string
+{
+    case Pending = 'pending';
+    case Active = 'active';
+    case Completed = 'completed';
+}

--- a/app/Enums/SortDirection.php
+++ b/app/Enums/SortDirection.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum SortDirection: string
+{
+    case Asc = 'asc';
+    case Desc = 'desc';
+}

--- a/app/Http/Controllers/Events/ListEventAttendeesController.php
+++ b/app/Http/Controllers/Events/ListEventAttendeesController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers\Events;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Events\ListEventAttendeesRequest;
+use App\Http\Resources\Events\EventAttendeeResource;
+use App\Models\Event;
+use App\Models\EventAttendee;
+use Illuminate\Contracts\Database\Eloquent\Builder;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Knuckles\Scribe\Attributes\Endpoint;
+use Knuckles\Scribe\Attributes\Group;
+use Knuckles\Scribe\Attributes\ResponseFromApiResource;
+use Knuckles\Scribe\Attributes\UrlParam;
+
+#[Group('Events', 'APIs for Events')]
+class ListEventAttendeesController extends Controller
+{
+    #[Endpoint('List Event Attendees', 'Paginated list of attendees for a publicly visible event.')]
+    #[UrlParam('event', 'string', 'The slug of the event.', example: 'london-grand-tournament')]
+    #[ResponseFromApiResource(EventAttendeeResource::class, model: EventAttendee::class, paginate: 15)]
+    public function __invoke(ListEventAttendeesRequest $request, Event $event): AnonymousResourceCollection
+    {
+        abort_unless($event->status->isPubliclyVisible(), 404);
+
+        $attendees = $event->attendees()
+            ->with(['user.clubs', 'faction'])
+            ->join('users', 'users.id', '=', 'event_attendees.user_id')
+            ->when($request->filled('search'), function (Builder $query) use ($request): void {
+                $term = '%'.$request->string('search').'%';
+
+                $query->where(function (Builder $query) use ($term): void {
+                    $query->whereHas('user', fn (Builder $q) => $q->where('users.name', 'like', $term))
+                        ->orWhereHas('faction', fn (Builder $q) => $q->where('factions.name', 'like', $term))
+                        ->orWhereHas('user.clubs', fn (Builder $q) => $q->where('clubs.name', 'like', $term));
+                });
+            })
+            ->orderBy('users.name')
+            ->select('event_attendees.*')
+            ->paginate();
+
+        return EventAttendeeResource::collection($attendees);
+    }
+}

--- a/app/Http/Controllers/Events/ListEventGalleryController.php
+++ b/app/Http/Controllers/Events/ListEventGalleryController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers\Events;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Gallery\PhotoResource;
+use App\Models\Event;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+class ListEventGalleryController extends Controller
+{
+    public function __invoke(Request $request, Event $event): AnonymousResourceCollection
+    {
+        abort_unless($event->status->isPubliclyVisible(), 404);
+
+        $user = $request->user('sanctum');
+
+        $photos = $event->photos()
+            ->when($user, fn ($query) => $query->withReactionData($user->id), fn ($query) => $query->withCount('reactions'))
+            ->latest()
+            ->paginate();
+
+        return PhotoResource::collection($photos);
+    }
+}

--- a/app/Http/Controllers/Events/ListEventRoundsController.php
+++ b/app/Http/Controllers/Events/ListEventRoundsController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers\Events;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Events\RoundResource;
+use App\Models\Event;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Knuckles\Scribe\Attributes\Endpoint;
+use Knuckles\Scribe\Attributes\Group;
+use Knuckles\Scribe\Attributes\UrlParam;
+
+#[Group('Events', 'APIs for Events')]
+class ListEventRoundsController extends Controller
+{
+    #[Endpoint('List Event Rounds', 'List rounds for an event. Only visible for Active/Completed events.')]
+    #[UrlParam('event', 'string', 'The slug of the event.', example: 'london-grand-tournament')]
+    public function __invoke(Event $event): AnonymousResourceCollection
+    {
+        abort_unless($event->status->hasRoundsVisible(), 404);
+
+        $rounds = $event->rounds()
+            ->orderBy('number')
+            ->get();
+
+        return RoundResource::collection($rounds);
+    }
+}

--- a/app/Http/Controllers/Events/ListEventStandingsController.php
+++ b/app/Http/Controllers/Events/ListEventStandingsController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers\Events;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Events\ListEventStandingsRequest;
+use App\Http\Resources\Events\EventStandingResource;
+use App\Models\Event;
+use App\Models\EventScoreType;
+use Illuminate\Contracts\Database\Eloquent\Builder;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+class ListEventStandingsController extends Controller
+{
+    public function __invoke(ListEventStandingsRequest $request, Event $event): AnonymousResourceCollection
+    {
+        abort_unless($event->status->isPubliclyVisible(), 404);
+        abort_unless($event->standings_visible, 404);
+
+        $query = $event->standings()
+            ->with(['attendee.user.clubs', 'attendee.faction', 'scores.scoreType']);
+
+        if ($request->filled('search')) {
+            $term = '%'.$request->string('search').'%';
+
+            $query->whereHas('attendee', function (Builder $q) use ($term): void {
+                $q->where(function (Builder $q) use ($term): void {
+                    $q->whereHas('user', fn (Builder $q) => $q->where('users.name', 'like', $term))
+                        ->orWhereHas('faction', fn (Builder $q) => $q->where('factions.name', 'like', $term))
+                        ->orWhereHas('user.clubs', fn (Builder $q) => $q->where('clubs.name', 'like', $term));
+                });
+            });
+        }
+
+        if ($request->filled('sort_by')) {
+            $scoreType = $event->scoreTypes()->where('slug', $request->input('sort_by'))->first();
+
+            abort_unless($scoreType instanceof EventScoreType, 422);
+
+            $query->join('event_standing_scores', function ($join) use ($scoreType): void {
+                $join->on('event_standings.id', '=', 'event_standing_scores.event_standing_id')
+                    ->where('event_standing_scores.event_score_type_id', '=', $scoreType->id);
+            })
+                ->orderBy('event_standing_scores.value', $scoreType->sort_direction->value)
+                ->select('event_standings.*');
+        } else {
+            $query->orderBy('position');
+        }
+
+        $standings = $query->paginate();
+
+        return EventStandingResource::collection($standings);
+    }
+}

--- a/app/Http/Controllers/Events/ListEventUpdatesController.php
+++ b/app/Http/Controllers/Events/ListEventUpdatesController.php
@@ -11,7 +11,6 @@ use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Knuckles\Scribe\Attributes\Endpoint;
 use Knuckles\Scribe\Attributes\Group;
 use Knuckles\Scribe\Attributes\ResponseFromApiResource;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 #[Group('Events', 'APIs for Events')]
 class ListEventUpdatesController extends Controller
@@ -20,9 +19,7 @@ class ListEventUpdatesController extends Controller
     #[ResponseFromApiResource(EventUpdateResource::class, model: EventUpdate::class, paginate: 15)]
     public function __invoke(Request $request, Event $event): AnonymousResourceCollection
     {
-        if (! $event->status->isPubliclyVisible()) {
-            throw new NotFoundHttpException();
-        }
+        abort_unless($event->status->isPubliclyVisible(), 404);
 
         $updates = $event->updates()
             ->with(['author', 'attachments'])

--- a/app/Http/Controllers/Events/ListEventUpdatesController.php
+++ b/app/Http/Controllers/Events/ListEventUpdatesController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers\Events;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Events\EventUpdateResource;
+use App\Models\Event;
+use App\Models\EventUpdate;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Knuckles\Scribe\Attributes\Endpoint;
+use Knuckles\Scribe\Attributes\Group;
+use Knuckles\Scribe\Attributes\ResponseFromApiResource;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+#[Group('Events', 'APIs for Events')]
+class ListEventUpdatesController extends Controller
+{
+    #[Endpoint('List Event Updates', 'List updates for a publicly visible event, pinned first then most recent.')]
+    #[ResponseFromApiResource(EventUpdateResource::class, model: EventUpdate::class, paginate: 15)]
+    public function __invoke(Request $request, Event $event): AnonymousResourceCollection
+    {
+        if (! $event->status->isPubliclyVisible()) {
+            throw new NotFoundHttpException();
+        }
+
+        $updates = $event->updates()
+            ->with(['author', 'attachments'])
+            ->orderByRaw('pinned_at IS NULL')
+            ->orderByDesc('pinned_at')
+            ->orderByDesc('published_at')
+            ->paginate();
+
+        return EventUpdateResource::collection($updates);
+    }
+}

--- a/app/Http/Controllers/Events/ListEventsController.php
+++ b/app/Http/Controllers/Events/ListEventsController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers\Events;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Events\ListEventsRequest;
+use App\Http\Resources\Events\EventResource;
+use App\Models\Event;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Knuckles\Scribe\Attributes\Endpoint;
+use Knuckles\Scribe\Attributes\Group;
+use Knuckles\Scribe\Attributes\ResponseFromApiResource;
+
+#[Group('Events', 'APIs for Events')]
+class ListEventsController extends Controller
+{
+    #[Endpoint('List Events', 'List publicly visible events with optional filters and search.')]
+    #[ResponseFromApiResource(EventResource::class, model: Event::class, paginate: 15)]
+    public function __invoke(ListEventsRequest $request): AnonymousResourceCollection
+    {
+        $events = Event::query()
+            ->publiclyVisible()
+            ->with('gameSystem')
+            ->when($request->filled('status'), fn ($query) => $query->where('status', $request->string('status')))
+            ->when(
+                $request->filled('game_system'),
+                fn ($query) => $query->whereHas('gameSystem', fn ($q) => $q->where('slug', $request->string('game_system'))),
+            )
+            ->when($request->filled('search'), fn ($query) => $query->where('name', 'like', '%'.$request->string('search').'%'))
+            ->orderBy('starts_at')
+            ->paginate();
+
+        return EventResource::collection($events);
+    }
+}

--- a/app/Http/Controllers/Events/ShowEventAttendeeController.php
+++ b/app/Http/Controllers/Events/ShowEventAttendeeController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers\Events;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Events\EventAttendeeDetailResource;
+use App\Models\Event;
+use App\Models\EventAttendee;
+use Knuckles\Scribe\Attributes\Endpoint;
+use Knuckles\Scribe\Attributes\Group;
+use Knuckles\Scribe\Attributes\ResponseFromApiResource;
+use Knuckles\Scribe\Attributes\UrlParam;
+
+#[Group('Events', 'APIs for Events')]
+class ShowEventAttendeeController extends Controller
+{
+    #[Endpoint('Show Event Attendee', 'Attendee detail for a publicly visible event.')]
+    #[UrlParam('event', 'string', 'The slug of the event.', example: 'london-grand-tournament')]
+    #[UrlParam('attendee', 'integer', 'The id of the attendee.', example: 1)]
+    #[ResponseFromApiResource(EventAttendeeDetailResource::class, model: EventAttendee::class)]
+    public function __invoke(Event $event, EventAttendee $attendee): EventAttendeeDetailResource
+    {
+        abort_unless($event->status->isPubliclyVisible(), 404);
+
+        $attendee->load(['user.clubs', 'faction']);
+
+        return EventAttendeeDetailResource::make($attendee);
+    }
+}

--- a/app/Http/Controllers/Events/ShowEventAttendeeController.php
+++ b/app/Http/Controllers/Events/ShowEventAttendeeController.php
@@ -22,7 +22,7 @@ class ShowEventAttendeeController extends Controller
     {
         abort_unless($event->status->isPubliclyVisible(), 404);
 
-        $attendee->load(['user.clubs', 'faction', 'customFieldResponses.field']);
+        $attendee->load(['user.clubs', 'faction', 'customFieldResponses.field', 'games.round', 'games.attendees.user']);
 
         return EventAttendeeDetailResource::make($attendee);
     }

--- a/app/Http/Controllers/Events/ShowEventAttendeeController.php
+++ b/app/Http/Controllers/Events/ShowEventAttendeeController.php
@@ -22,7 +22,7 @@ class ShowEventAttendeeController extends Controller
     {
         abort_unless($event->status->isPubliclyVisible(), 404);
 
-        $attendee->load(['user.clubs', 'faction']);
+        $attendee->load(['user.clubs', 'faction', 'customFieldResponses.field']);
 
         return EventAttendeeDetailResource::make($attendee);
     }

--- a/app/Http/Controllers/Events/ShowEventController.php
+++ b/app/Http/Controllers/Events/ShowEventController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers\Events;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Events\EventResource;
+use App\Models\Event;
+use Illuminate\Http\Request;
+use Knuckles\Scribe\Attributes\Endpoint;
+use Knuckles\Scribe\Attributes\Group;
+use Knuckles\Scribe\Attributes\ResponseFromApiResource;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+#[Group('Events', 'APIs for Events')]
+class ShowEventController extends Controller
+{
+    #[Endpoint('Show Event', 'Get a publicly visible event by slug.')]
+    #[ResponseFromApiResource(EventResource::class, model: Event::class)]
+    public function __invoke(Request $request, Event $event): EventResource
+    {
+        if (! $event->status->isPubliclyVisible()) {
+            throw new NotFoundHttpException();
+        }
+
+        $event->load(['gameSystem', 'documents']);
+
+        return EventResource::make($event);
+    }
+}

--- a/app/Http/Controllers/Events/ShowEventController.php
+++ b/app/Http/Controllers/Events/ShowEventController.php
@@ -9,7 +9,6 @@ use Illuminate\Http\Request;
 use Knuckles\Scribe\Attributes\Endpoint;
 use Knuckles\Scribe\Attributes\Group;
 use Knuckles\Scribe\Attributes\ResponseFromApiResource;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 #[Group('Events', 'APIs for Events')]
 class ShowEventController extends Controller
@@ -18,9 +17,7 @@ class ShowEventController extends Controller
     #[ResponseFromApiResource(EventResource::class, model: Event::class)]
     public function __invoke(Request $request, Event $event): EventResource
     {
-        if (! $event->status->isPubliclyVisible()) {
-            throw new NotFoundHttpException();
-        }
+        abort_unless($event->status->isPubliclyVisible(), 404);
 
         $event->load(['gameSystem', 'documents']);
 

--- a/app/Http/Controllers/Events/ShowEventGameController.php
+++ b/app/Http/Controllers/Events/ShowEventGameController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers\Events;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Events\GameDetailResource;
+use App\Models\Event;
+use App\Models\Game;
+use Knuckles\Scribe\Attributes\Endpoint;
+use Knuckles\Scribe\Attributes\Group;
+use Knuckles\Scribe\Attributes\UrlParam;
+
+#[Group('Events', 'APIs for Events')]
+class ShowEventGameController extends Controller
+{
+    #[Endpoint('Show Event Game', 'Game detail with full score breakdown and army lists.')]
+    #[UrlParam('event', 'string', 'The slug of the event.', example: 'london-grand-tournament')]
+    #[UrlParam('game', 'integer', 'The id of the game.', example: 1)]
+    public function __invoke(Event $event, Game $game): GameDetailResource
+    {
+        abort_unless($event->status->isPubliclyVisible(), 404);
+        abort_unless($game->round->event_id === $event->id, 404);
+
+        $game->load(['round', 'attendees.user', 'attendees.faction']);
+
+        return GameDetailResource::make($game);
+    }
+}

--- a/app/Http/Controllers/Events/ShowEventGameController.php
+++ b/app/Http/Controllers/Events/ShowEventGameController.php
@@ -19,9 +19,10 @@ class ShowEventGameController extends Controller
     public function __invoke(Event $event, Game $game): GameDetailResource
     {
         abort_unless($event->status->isPubliclyVisible(), 404);
-        abort_unless($game->round->event_id === $event->id, 404);
 
         $game->load(['round', 'attendees.user', 'attendees.faction']);
+
+        abort_unless($game->round->event_id === $event->id, 404);
 
         return GameDetailResource::make($game);
     }

--- a/app/Http/Controllers/Events/ShowEventRoundController.php
+++ b/app/Http/Controllers/Events/ShowEventRoundController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers\Events;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Events\RoundDetailResource;
+use App\Models\Event;
+use App\Models\Round;
+use Knuckles\Scribe\Attributes\Endpoint;
+use Knuckles\Scribe\Attributes\Group;
+use Knuckles\Scribe\Attributes\UrlParam;
+
+#[Group('Events', 'APIs for Events')]
+class ShowEventRoundController extends Controller
+{
+    #[Endpoint('Show Event Round', 'Round detail with games for an event.')]
+    #[UrlParam('event', 'string', 'The slug of the event.', example: 'london-grand-tournament')]
+    #[UrlParam('round', 'integer', 'The id of the round.', example: 1)]
+    public function __invoke(Event $event, Round $round): RoundDetailResource
+    {
+        abort_unless($event->status->hasRoundsVisible(), 404);
+
+        $round->load(['games' => fn ($q) => $q->orderBy('table_number'), 'games.attendees.user', 'games.attendees.faction']);
+
+        return RoundDetailResource::make($round);
+    }
+}

--- a/app/Http/Requests/Events/ListEventAttendeesRequest.php
+++ b/app/Http/Requests/Events/ListEventAttendeesRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests\Events;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class ListEventAttendeesRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'search' => ['sometimes', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Http/Requests/Events/ListEventStandingsRequest.php
+++ b/app/Http/Requests/Events/ListEventStandingsRequest.php
@@ -19,6 +19,7 @@ class ListEventStandingsRequest extends FormRequest
     {
         return [
             'search' => ['sometimes', 'string', 'max:255'],
+            'sort_by' => ['sometimes', 'string', 'max:255'],
         ];
     }
 }

--- a/app/Http/Requests/Events/ListEventStandingsRequest.php
+++ b/app/Http/Requests/Events/ListEventStandingsRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests\Events;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class ListEventStandingsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'search' => ['sometimes', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Http/Requests/Events/ListEventsRequest.php
+++ b/app/Http/Requests/Events/ListEventsRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests\Events;
+
+use App\Enums\EventStatus;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Enum;
+
+class ListEventsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'search' => ['sometimes', 'string', 'max:255'],
+            'status' => [
+                'sometimes',
+                'string',
+                new Enum(EventStatus::class),
+                function (string $attribute, mixed $value, \Closure $fail): void {
+                    $status = EventStatus::tryFrom((string) $value);
+                    if ($status !== null && ! $status->isPubliclyVisible()) {
+                        $fail('The selected status is not available.');
+                    }
+                },
+            ],
+            'game_system' => ['sometimes', 'string', Rule::exists('game_systems', 'slug')],
+        ];
+    }
+}

--- a/app/Http/Resources/Events/EventAttendeeDetailResource.php
+++ b/app/Http/Resources/Events/EventAttendeeDetailResource.php
@@ -5,6 +5,7 @@ namespace App\Http\Resources\Events;
 use App\Enums\CustomFieldType;
 use App\Models\EventAttendee;
 use App\Models\EventCustomFieldResponse;
+use App\Models\Game;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -44,7 +45,23 @@ class EventAttendeeDetailResource extends JsonResource
                     'value' => $this->interpretValue($response),
                 ])
                 ->all(),
-            'games' => [],
+            'games' => $this->games
+                ->sortBy(fn (Game $game): int => $game->round->number)
+                ->values()
+                ->map(fn (Game $game): array => [
+                    'id' => $game->id,
+                    'round_number' => $game->round->number,
+                    'table_number' => $game->table_number,
+                    'is_bye' => $game->is_bye,
+                    'score' => $game->pivot?->score,
+                    'opponents' => $game->attendees
+                        ->reject(fn (EventAttendee $a): bool => $a->id === $this->id)
+                        ->values()
+                        ->map(fn (EventAttendee $a): array => [
+                            'id' => $a->id,
+                            'name' => $a->user->public_name,
+                        ])->all(),
+                ])->all(),
         ];
     }
 

--- a/app/Http/Resources/Events/EventAttendeeDetailResource.php
+++ b/app/Http/Resources/Events/EventAttendeeDetailResource.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Resources\Events;
 
+use App\Enums\CustomFieldType;
 use App\Models\EventAttendee;
+use App\Models\EventCustomFieldResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -32,7 +34,30 @@ class EventAttendeeDetailResource extends JsonResource
             ])->values(),
             'army_list' => $this->army_list,
             'checked_in_at' => $this->checked_in_at?->toIso8601ZuluString(),
+            'custom_field_responses' => $this->customFieldResponses
+                ->sortBy(fn (EventCustomFieldResponse $response): int => $response->field->display_order)
+                ->values()
+                ->map(fn (EventCustomFieldResponse $response): array => [
+                    'id' => $response->field->id,
+                    'name' => $response->field->name,
+                    'type' => $response->field->type->value,
+                    'value' => $this->interpretValue($response),
+                ])
+                ->all(),
             'games' => [],
         ];
+    }
+
+    private function interpretValue(EventCustomFieldResponse $response): string|int|bool|null
+    {
+        if ($response->value === null) {
+            return null;
+        }
+
+        return match ($response->field->type) {
+            CustomFieldType::Checkbox => filter_var($response->value, FILTER_VALIDATE_BOOLEAN),
+            CustomFieldType::Number => (int) $response->value,
+            default => $response->value,
+        };
     }
 }

--- a/app/Http/Resources/Events/EventAttendeeDetailResource.php
+++ b/app/Http/Resources/Events/EventAttendeeDetailResource.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Resources\Events;
+
+use App\Models\EventAttendee;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin EventAttendee
+ */
+class EventAttendeeDetailResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'user' => [
+                'id' => $this->user->id,
+                'name' => $this->user->public_name,
+            ],
+            'faction' => $this->faction ? [
+                'id' => $this->faction->id,
+                'name' => $this->faction->name,
+            ] : null,
+            'clubs' => $this->user->clubs->map(fn ($club) => [
+                'id' => $club->id,
+                'name' => $club->name,
+            ])->values(),
+            'army_list' => $this->army_list,
+            'checked_in_at' => $this->checked_in_at?->toIso8601ZuluString(),
+            'games' => [],
+        ];
+    }
+}

--- a/app/Http/Resources/Events/EventAttendeeResource.php
+++ b/app/Http/Resources/Events/EventAttendeeResource.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Resources\Events;
+
+use App\Models\EventAttendee;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin EventAttendee
+ */
+class EventAttendeeResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'user' => [
+                'id' => $this->user->id,
+                'name' => $this->user->public_name,
+            ],
+            'faction' => $this->faction ? [
+                'id' => $this->faction->id,
+                'name' => $this->faction->name,
+            ] : null,
+            'clubs' => $this->user->clubs->map(fn ($club) => [
+                'id' => $club->id,
+                'name' => $club->name,
+            ])->values(),
+        ];
+    }
+}

--- a/app/Http/Resources/Events/EventDocumentResource.php
+++ b/app/Http/Resources/Events/EventDocumentResource.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Resources\Events;
+
+use App\Models\EventDocument;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin EventDocument
+ */
+class EventDocumentResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'url' => $this->url,
+            'created_at' => $this->created_at?->toIso8601ZuluString(),
+        ];
+    }
+}

--- a/app/Http/Resources/Events/EventResource.php
+++ b/app/Http/Resources/Events/EventResource.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Resources\Events;
+
+use App\Models\Event;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin Event
+ */
+class EventResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'description' => $this->description,
+            'status' => $this->status->value,
+            'pairing_format' => $this->pairing_format->value,
+            'starts_at' => $this->starts_at->toIso8601ZuluString(),
+            'ends_at' => $this->ends_at->toIso8601ZuluString(),
+            'max_attendees' => $this->max_attendees,
+            'venue' => [
+                'name' => $this->venue_name,
+                'address' => $this->venue_address,
+                'city' => $this->venue_city,
+                'country' => $this->venue_country?->value,
+            ],
+            'game_system' => GameSystemResource::make($this->whenLoaded('gameSystem')),
+            'documents' => EventDocumentResource::collection($this->whenLoaded('documents')),
+            'created_at' => $this->created_at?->toIso8601ZuluString(),
+            'updated_at' => $this->updated_at?->toIso8601ZuluString(),
+        ];
+    }
+}

--- a/app/Http/Resources/Events/EventStandingResource.php
+++ b/app/Http/Resources/Events/EventStandingResource.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Resources\Events;
+
+use App\Models\EventStanding;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin EventStanding
+ */
+class EventStandingResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'position' => $this->position,
+            'attendee' => [
+                'id' => $this->attendee->id,
+                'name' => $this->attendee->user->public_name,
+                'faction' => $this->attendee->faction ? [
+                    'id' => $this->attendee->faction->id,
+                    'name' => $this->attendee->faction->name,
+                ] : null,
+                'clubs' => $this->attendee->user->clubs->map(fn ($club) => [
+                    'id' => $club->id,
+                    'name' => $club->name,
+                ])->values(),
+            ],
+            'scores' => $this->scores->map(fn ($score) => [
+                'value' => $score->value,
+                'score_type' => [
+                    'id' => $score->scoreType->id,
+                    'name' => $score->scoreType->name,
+                    'slug' => $score->scoreType->slug,
+                    'sort_direction' => $score->scoreType->sort_direction->value,
+                ],
+            ])->values(),
+        ];
+    }
+}

--- a/app/Http/Resources/Events/EventUpdateAttachmentResource.php
+++ b/app/Http/Resources/Events/EventUpdateAttachmentResource.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Resources\Events;
+
+use App\Models\EventUpdateAttachment;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin EventUpdateAttachment
+ */
+class EventUpdateAttachmentResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'url' => $this->url,
+            'display_order' => $this->display_order,
+        ];
+    }
+}

--- a/app/Http/Resources/Events/EventUpdateResource.php
+++ b/app/Http/Resources/Events/EventUpdateResource.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Resources\Events;
+
+use App\Models\EventUpdate;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin EventUpdate
+ */
+class EventUpdateResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'title' => $this->title,
+            'body' => $this->body,
+            'pinned' => $this->pinned_at !== null,
+            'published_at' => $this->published_at->toIso8601ZuluString(),
+            'author' => [
+                'id' => $this->author->id,
+                'name' => $this->author->name,
+            ],
+            'attachments' => EventUpdateAttachmentResource::collection($this->whenLoaded('attachments')),
+            'created_at' => $this->created_at?->toIso8601ZuluString(),
+            'updated_at' => $this->updated_at?->toIso8601ZuluString(),
+        ];
+    }
+}

--- a/app/Http/Resources/Events/GameDetailResource.php
+++ b/app/Http/Resources/Events/GameDetailResource.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Resources\Events;
+
+use App\Models\EventAttendee;
+use App\Models\Game;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin Game
+ */
+class GameDetailResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'table_number' => $this->table_number,
+            'is_bye' => $this->is_bye,
+            'round' => [
+                'id' => $this->round->id,
+                'number' => $this->round->number,
+                'name' => $this->round->name,
+            ],
+            'attendees' => $this->attendees->map(fn (EventAttendee $attendee): array => [
+                'id' => $attendee->id,
+                'user' => [
+                    'id' => $attendee->user->id,
+                    'name' => $attendee->user->public_name,
+                ],
+                'faction' => $attendee->faction ? [
+                    'id' => $attendee->faction->id,
+                    'name' => $attendee->faction->name,
+                ] : null,
+                'army_list' => $attendee->army_list,
+                'score' => $attendee->pivot?->score,
+            ])->all(),
+        ];
+    }
+}

--- a/app/Http/Resources/Events/GameSystemResource.php
+++ b/app/Http/Resources/Events/GameSystemResource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Resources\Events;
+
+use App\Models\GameSystem;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin GameSystem
+ */
+class GameSystemResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'slug' => $this->slug,
+        ];
+    }
+}

--- a/app/Http/Resources/Events/RoundDetailResource.php
+++ b/app/Http/Resources/Events/RoundDetailResource.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Resources\Events;
+
+use App\Models\EventAttendee;
+use App\Models\Game;
+use App\Models\Round;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin Round
+ */
+class RoundDetailResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'number' => $this->number,
+            'name' => $this->name,
+            'games' => $this->games->map(fn (Game $game): array => [
+                'id' => $game->id,
+                'table_number' => $game->table_number,
+                'is_bye' => $game->is_bye,
+                'attendees' => $game->attendees->map(fn (EventAttendee $attendee): array => [
+                    'id' => $attendee->id,
+                    'user' => [
+                        'id' => $attendee->user->id,
+                        'name' => $attendee->user->public_name,
+                    ],
+                    'faction' => $attendee->faction ? [
+                        'id' => $attendee->faction->id,
+                        'name' => $attendee->faction->name,
+                    ] : null,
+                    'score' => $attendee->pivot?->score,
+                ])->all(),
+            ])->all(),
+        ];
+    }
+}

--- a/app/Http/Resources/Events/RoundResource.php
+++ b/app/Http/Resources/Events/RoundResource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Resources\Events;
+
+use App\Models\Round;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin Round
+ */
+class RoundResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'number' => $this->number,
+            'name' => $this->name,
+        ];
+    }
+}

--- a/app/Models/Club.php
+++ b/app/Models/Club.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\Country;
+use Database\Factories\ClubFactory;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $slug
+ * @property string|null $city
+ * @property Country|null $country
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Collection<int, Event> $events
+ * @property-read int|null $events_count
+ * @property-read Collection<int, User> $members
+ * @property-read int|null $members_count
+ *
+ * @method static \Database\Factories\ClubFactory factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Club newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Club newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Club query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Club whereCity($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Club whereCountry($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Club whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Club whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Club whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Club whereSlug($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Club whereUpdatedAt($value)
+ *
+ * @mixin \Eloquent
+ */
+class Club extends Model
+{
+    /** @use HasFactory<ClubFactory> */
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+        'slug',
+        'city',
+        'country',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'country' => Country::class,
+        ];
+    }
+
+    public function getRouteKeyName(): string
+    {
+        return 'slug';
+    }
+
+    /**
+     * @return BelongsToMany<User, $this>
+     */
+    public function members(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class)->withTimestamps();
+    }
+
+    /**
+     * @return HasMany<Event, $this>
+     */
+    public function events(): HasMany
+    {
+        return $this->hasMany(Event::class);
+    }
+}

--- a/app/Models/Conversation.php
+++ b/app/Models/Conversation.php
@@ -20,10 +20,10 @@ use Illuminate\Support\Carbon;
  * @property int|null $event_id
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
+ * @property-read int|null $unread_count
  * @property-read Message|null $latestMessage
  * @property-read Collection<int, Message> $messages
  * @property-read int|null $messages_count
- * @property-read int|null $unread_count
  * @property-read Collection<int, User> $users
  * @property-read int|null $users_count
  *

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\Country;
+use App\Enums\EventStatus;
+use App\Enums\PairingFormat;
+use Database\Factories\EventFactory;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int $game_system_id
+ * @property int|null $club_id
+ * @property string $name
+ * @property string $slug
+ * @property string|null $description
+ * @property EventStatus $status
+ * @property PairingFormat $pairing_format
+ * @property Carbon $starts_at
+ * @property Carbon $ends_at
+ * @property string|null $venue_name
+ * @property string|null $venue_address
+ * @property string|null $venue_city
+ * @property Country|null $venue_country
+ * @property int|null $max_attendees
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Club|null $club
+ * @property-read Collection<int, EventDocument> $documents
+ * @property-read int|null $documents_count
+ * @property-read GameSystem $gameSystem
+ *
+ * @method static \Database\Factories\EventFactory factory($count = null, $state = [])
+ * @method static Builder<static>|Event newModelQuery()
+ * @method static Builder<static>|Event newQuery()
+ * @method static Builder<static>|Event publiclyVisible()
+ * @method static Builder<static>|Event query()
+ * @method static Builder<static>|Event whereClubId($value)
+ * @method static Builder<static>|Event whereCreatedAt($value)
+ * @method static Builder<static>|Event whereDescription($value)
+ * @method static Builder<static>|Event whereEndsAt($value)
+ * @method static Builder<static>|Event whereGameSystemId($value)
+ * @method static Builder<static>|Event whereId($value)
+ * @method static Builder<static>|Event whereMaxAttendees($value)
+ * @method static Builder<static>|Event whereName($value)
+ * @method static Builder<static>|Event wherePairingFormat($value)
+ * @method static Builder<static>|Event whereSlug($value)
+ * @method static Builder<static>|Event whereStartsAt($value)
+ * @method static Builder<static>|Event whereStatus($value)
+ * @method static Builder<static>|Event whereUpdatedAt($value)
+ * @method static Builder<static>|Event whereVenueAddress($value)
+ * @method static Builder<static>|Event whereVenueCity($value)
+ * @method static Builder<static>|Event whereVenueCountry($value)
+ * @method static Builder<static>|Event whereVenueName($value)
+ *
+ * @mixin \Eloquent
+ */
+class Event extends Model
+{
+    /** @use HasFactory<EventFactory> */
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'game_system_id',
+        'club_id',
+        'name',
+        'slug',
+        'description',
+        'status',
+        'pairing_format',
+        'starts_at',
+        'ends_at',
+        'venue_name',
+        'venue_address',
+        'venue_city',
+        'venue_country',
+        'max_attendees',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'status' => EventStatus::class,
+            'pairing_format' => PairingFormat::class,
+            'venue_country' => Country::class,
+            'starts_at' => 'datetime',
+            'ends_at' => 'datetime',
+        ];
+    }
+
+    public function getRouteKeyName(): string
+    {
+        return 'slug';
+    }
+
+    /**
+     * @param  Builder<self>  $query
+     */
+    public function scopePubliclyVisible(Builder $query): void
+    {
+        $query->whereIn('status', array_map(
+            fn (EventStatus $status): string => $status->value,
+            array_filter(EventStatus::cases(), fn (EventStatus $status): bool => $status->isPubliclyVisible()),
+        ));
+    }
+
+    /**
+     * @return BelongsTo<GameSystem, $this>
+     */
+    public function gameSystem(): BelongsTo
+    {
+        return $this->belongsTo(GameSystem::class);
+    }
+
+    /**
+     * @return BelongsTo<Club, $this>
+     */
+    public function club(): BelongsTo
+    {
+        return $this->belongsTo(Club::class);
+    }
+
+    /**
+     * @return HasMany<EventDocument, $this>
+     */
+    public function documents(): HasMany
+    {
+        return $this->hasMany(EventDocument::class);
+    }
+}

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -30,14 +30,19 @@ use Illuminate\Support\Carbon;
  * @property string|null $venue_city
  * @property Country|null $venue_country
  * @property int|null $max_attendees
+ * @property bool $standings_visible
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
+ * @property-read Collection<int, EventAttendee> $attendees
+ * @property-read int|null $attendees_count
  * @property-read Club|null $club
  * @property-read Collection<int, EventDocument> $documents
  * @property-read int|null $documents_count
+ * @property-read GameSystem $gameSystem
+ * @property-read Collection<int, Round> $rounds
+ * @property-read int|null $rounds_count
  * @property-read Collection<int, EventUpdate> $updates
  * @property-read int|null $updates_count
- * @property-read GameSystem $gameSystem
  *
  * @method static \Database\Factories\EventFactory factory($count = null, $state = [])
  * @method static Builder<static>|Event newModelQuery()
@@ -54,6 +59,7 @@ use Illuminate\Support\Carbon;
  * @method static Builder<static>|Event whereName($value)
  * @method static Builder<static>|Event wherePairingFormat($value)
  * @method static Builder<static>|Event whereSlug($value)
+ * @method static Builder<static>|Event whereStandingsVisible($value)
  * @method static Builder<static>|Event whereStartsAt($value)
  * @method static Builder<static>|Event whereStatus($value)
  * @method static Builder<static>|Event whereUpdatedAt($value)
@@ -87,6 +93,7 @@ class Event extends Model
         'venue_city',
         'venue_country',
         'max_attendees',
+        'standings_visible',
     ];
 
     /**
@@ -100,6 +107,7 @@ class Event extends Model
             'venue_country' => Country::class,
             'starts_at' => 'datetime',
             'ends_at' => 'datetime',
+            'standings_visible' => 'boolean',
         ];
     }
 
@@ -165,5 +173,21 @@ class Event extends Model
     public function rounds(): HasMany
     {
         return $this->hasMany(Round::class);
+    }
+
+    /**
+     * @return HasMany<EventScoreType, $this>
+     */
+    public function scoreTypes(): HasMany
+    {
+        return $this->hasMany(EventScoreType::class);
+    }
+
+    /**
+     * @return HasMany<EventStanding, $this>
+     */
+    public function standings(): HasMany
+    {
+        return $this->hasMany(EventStanding::class);
     }
 }

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -39,8 +39,14 @@ use Illuminate\Support\Carbon;
  * @property-read Collection<int, EventDocument> $documents
  * @property-read int|null $documents_count
  * @property-read GameSystem $gameSystem
+ * @property-read Collection<int, Photo> $photos
+ * @property-read int|null $photos_count
  * @property-read Collection<int, Round> $rounds
  * @property-read int|null $rounds_count
+ * @property-read Collection<int, EventScoreType> $scoreTypes
+ * @property-read int|null $score_types_count
+ * @property-read Collection<int, EventStanding> $standings
+ * @property-read int|null $standings_count
  * @property-read Collection<int, EventUpdate> $updates
  * @property-read int|null $updates_count
  *
@@ -149,6 +155,14 @@ class Event extends Model
     public function documents(): HasMany
     {
         return $this->hasMany(EventDocument::class);
+    }
+
+    /**
+     * @return HasMany<Photo, $this>
+     */
+    public function photos(): HasMany
+    {
+        return $this->hasMany(Photo::class);
     }
 
     /**

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -150,4 +150,12 @@ class Event extends Model
     {
         return $this->hasMany(EventUpdate::class);
     }
+
+    /**
+     * @return HasMany<EventAttendee, $this>
+     */
+    public function attendees(): HasMany
+    {
+        return $this->hasMany(EventAttendee::class);
+    }
 }

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -35,6 +35,8 @@ use Illuminate\Support\Carbon;
  * @property-read Club|null $club
  * @property-read Collection<int, EventDocument> $documents
  * @property-read int|null $documents_count
+ * @property-read Collection<int, EventUpdate> $updates
+ * @property-read int|null $updates_count
  * @property-read GameSystem $gameSystem
  *
  * @method static \Database\Factories\EventFactory factory($count = null, $state = [])
@@ -139,5 +141,13 @@ class Event extends Model
     public function documents(): HasMany
     {
         return $this->hasMany(EventDocument::class);
+    }
+
+    /**
+     * @return HasMany<EventUpdate, $this>
+     */
+    public function updates(): HasMany
+    {
+        return $this->hasMany(EventUpdate::class);
     }
 }

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -158,4 +158,12 @@ class Event extends Model
     {
         return $this->hasMany(EventAttendee::class);
     }
+
+    /**
+     * @return HasMany<Round, $this>
+     */
+    public function rounds(): HasMany
+    {
+        return $this->hasMany(Round::class);
+    }
 }

--- a/app/Models/EventAttendee.php
+++ b/app/Models/EventAttendee.php
@@ -20,13 +20,29 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $checked_in_at
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
- * @property-read Event $event
- * @property-read User $user
- * @property-read Faction|null $faction
  * @property-read Collection<int, EventCustomFieldResponse> $customFieldResponses
+ * @property-read int|null $custom_field_responses_count
+ * @property-read Event $event
+ * @property-read Faction|null $faction
  * @property-read GameAttendeePivot|null $pivot
+ * @property-read Collection<int, Game> $games
+ * @property-read int|null $games_count
+ * @property-read User $user
  *
- * @method static EventAttendeeFactory factory($count = null, $state = [])
+ * @method static \Database\Factories\EventAttendeeFactory factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventAttendee newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventAttendee newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventAttendee query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventAttendee whereArmyList($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventAttendee whereCheckedInAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventAttendee whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventAttendee whereEventId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventAttendee whereFactionId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventAttendee whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventAttendee whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventAttendee whereUserId($value)
+ *
+ * @mixin \Eloquent
  */
 class EventAttendee extends Model
 {

--- a/app/Models/EventAttendee.php
+++ b/app/Models/EventAttendee.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
 
@@ -23,6 +24,7 @@ use Illuminate\Support\Carbon;
  * @property-read User $user
  * @property-read Faction|null $faction
  * @property-read Collection<int, EventCustomFieldResponse> $customFieldResponses
+ * @property-read GameAttendeePivot|null $pivot
  *
  * @method static EventAttendeeFactory factory($count = null, $state = [])
  */
@@ -82,5 +84,16 @@ class EventAttendee extends Model
     public function customFieldResponses(): HasMany
     {
         return $this->hasMany(EventCustomFieldResponse::class);
+    }
+
+    /**
+     * @return BelongsToMany<Game, $this, GameAttendeePivot>
+     */
+    public function games(): BelongsToMany
+    {
+        return $this->belongsToMany(Game::class, 'game_attendee')
+            ->using(GameAttendeePivot::class)
+            ->withPivot('score')
+            ->withTimestamps();
     }
 }

--- a/app/Models/EventAttendee.php
+++ b/app/Models/EventAttendee.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\EventAttendeeFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int $event_id
+ * @property int $user_id
+ * @property int|null $faction_id
+ * @property string|null $army_list
+ * @property Carbon|null $checked_in_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Event $event
+ * @property-read User $user
+ * @property-read Faction|null $faction
+ *
+ * @method static EventAttendeeFactory factory($count = null, $state = [])
+ */
+class EventAttendee extends Model
+{
+    /** @use HasFactory<EventAttendeeFactory> */
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'event_id',
+        'user_id',
+        'faction_id',
+        'army_list',
+        'checked_in_at',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'checked_in_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<Event, $this>
+     */
+    public function event(): BelongsTo
+    {
+        return $this->belongsTo(Event::class);
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @return BelongsTo<Faction, $this>
+     */
+    public function faction(): BelongsTo
+    {
+        return $this->belongsTo(Faction::class);
+    }
+}

--- a/app/Models/EventCustomField.php
+++ b/app/Models/EventCustomField.php
@@ -2,7 +2,8 @@
 
 namespace App\Models;
 
-use Database\Factories\EventAttendeeFactory;
+use App\Enums\CustomFieldType;
+use Database\Factories\EventCustomFieldFactory;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -13,22 +14,20 @@ use Illuminate\Support\Carbon;
 /**
  * @property int $id
  * @property int $event_id
- * @property int $user_id
- * @property int|null $faction_id
- * @property string|null $army_list
- * @property Carbon|null $checked_in_at
+ * @property string $name
+ * @property CustomFieldType $type
+ * @property array<int, string>|null $options
+ * @property int $display_order
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property-read Event $event
- * @property-read User $user
- * @property-read Faction|null $faction
- * @property-read Collection<int, EventCustomFieldResponse> $customFieldResponses
+ * @property-read Collection<int, EventCustomFieldResponse> $responses
  *
- * @method static EventAttendeeFactory factory($count = null, $state = [])
+ * @method static EventCustomFieldFactory factory($count = null, $state = [])
  */
-class EventAttendee extends Model
+class EventCustomField extends Model
 {
-    /** @use HasFactory<EventAttendeeFactory> */
+    /** @use HasFactory<EventCustomFieldFactory> */
     use HasFactory;
 
     /**
@@ -36,10 +35,10 @@ class EventAttendee extends Model
      */
     protected $fillable = [
         'event_id',
-        'user_id',
-        'faction_id',
-        'army_list',
-        'checked_in_at',
+        'name',
+        'type',
+        'options',
+        'display_order',
     ];
 
     /**
@@ -48,7 +47,8 @@ class EventAttendee extends Model
     protected function casts(): array
     {
         return [
-            'checked_in_at' => 'datetime',
+            'type' => CustomFieldType::class,
+            'options' => 'array',
         ];
     }
 
@@ -61,25 +61,9 @@ class EventAttendee extends Model
     }
 
     /**
-     * @return BelongsTo<User, $this>
-     */
-    public function user(): BelongsTo
-    {
-        return $this->belongsTo(User::class);
-    }
-
-    /**
-     * @return BelongsTo<Faction, $this>
-     */
-    public function faction(): BelongsTo
-    {
-        return $this->belongsTo(Faction::class);
-    }
-
-    /**
      * @return HasMany<EventCustomFieldResponse, $this>
      */
-    public function customFieldResponses(): HasMany
+    public function responses(): HasMany
     {
         return $this->hasMany(EventCustomFieldResponse::class);
     }

--- a/app/Models/EventCustomField.php
+++ b/app/Models/EventCustomField.php
@@ -16,14 +16,28 @@ use Illuminate\Support\Carbon;
  * @property int $event_id
  * @property string $name
  * @property CustomFieldType $type
- * @property array<int, string>|null $options
+ * @property array<array-key, mixed>|null $options
  * @property int $display_order
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property-read Event $event
  * @property-read Collection<int, EventCustomFieldResponse> $responses
+ * @property-read int|null $responses_count
  *
- * @method static EventCustomFieldFactory factory($count = null, $state = [])
+ * @method static \Database\Factories\EventCustomFieldFactory factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventCustomField newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventCustomField newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventCustomField query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventCustomField whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventCustomField whereDisplayOrder($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventCustomField whereEventId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventCustomField whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventCustomField whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventCustomField whereOptions($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventCustomField whereType($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventCustomField whereUpdatedAt($value)
+ *
+ * @mixin \Eloquent
  */
 class EventCustomField extends Model
 {

--- a/app/Models/EventCustomFieldResponse.php
+++ b/app/Models/EventCustomFieldResponse.php
@@ -18,7 +18,18 @@ use Illuminate\Support\Carbon;
  * @property-read EventAttendee $attendee
  * @property-read EventCustomField $field
  *
- * @method static EventCustomFieldResponseFactory factory($count = null, $state = [])
+ * @method static \Database\Factories\EventCustomFieldResponseFactory factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventCustomFieldResponse newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventCustomFieldResponse newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventCustomFieldResponse query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventCustomFieldResponse whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventCustomFieldResponse whereEventAttendeeId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventCustomFieldResponse whereEventCustomFieldId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventCustomFieldResponse whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventCustomFieldResponse whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventCustomFieldResponse whereValue($value)
+ *
+ * @mixin \Eloquent
  */
 class EventCustomFieldResponse extends Model
 {

--- a/app/Models/EventCustomFieldResponse.php
+++ b/app/Models/EventCustomFieldResponse.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\EventCustomFieldResponseFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int $event_attendee_id
+ * @property int $event_custom_field_id
+ * @property string|null $value
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read EventAttendee $attendee
+ * @property-read EventCustomField $field
+ *
+ * @method static EventCustomFieldResponseFactory factory($count = null, $state = [])
+ */
+class EventCustomFieldResponse extends Model
+{
+    /** @use HasFactory<EventCustomFieldResponseFactory> */
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'event_attendee_id',
+        'event_custom_field_id',
+        'value',
+    ];
+
+    /**
+     * @return BelongsTo<EventAttendee, $this>
+     */
+    public function attendee(): BelongsTo
+    {
+        return $this->belongsTo(EventAttendee::class, 'event_attendee_id');
+    }
+
+    /**
+     * @return BelongsTo<EventCustomField, $this>
+     */
+    public function field(): BelongsTo
+    {
+        return $this->belongsTo(EventCustomField::class, 'event_custom_field_id');
+    }
+}

--- a/app/Models/EventDocument.php
+++ b/app/Models/EventDocument.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\EventDocumentFactory;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * @property int $id
+ * @property int $event_id
+ * @property string $name
+ * @property string $path
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Event $event
+ * @property-read string $url
+ *
+ * @method static \Database\Factories\EventDocumentFactory factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventDocument newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventDocument newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventDocument query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventDocument whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventDocument whereEventId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventDocument whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventDocument whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventDocument wherePath($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventDocument whereUpdatedAt($value)
+ *
+ * @mixin \Eloquent
+ */
+class EventDocument extends Model
+{
+    /** @use HasFactory<EventDocumentFactory> */
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'event_id',
+        'name',
+        'path',
+    ];
+
+    /**
+     * @return BelongsTo<Event, $this>
+     */
+    public function event(): BelongsTo
+    {
+        return $this->belongsTo(Event::class);
+    }
+
+    protected function url(): Attribute
+    {
+        return Attribute::get(fn (): string => Storage::disk('public')->url($this->path));
+    }
+}

--- a/app/Models/EventScoreType.php
+++ b/app/Models/EventScoreType.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\SortDirection;
+use Database\Factories\EventScoreTypeFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int $event_id
+ * @property string $name
+ * @property string $slug
+ * @property SortDirection $sort_direction
+ * @property int $display_order
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Event $event
+ *
+ * @method static EventScoreTypeFactory factory($count = null, $state = [])
+ */
+class EventScoreType extends Model
+{
+    /** @use HasFactory<EventScoreTypeFactory> */
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'event_id',
+        'name',
+        'slug',
+        'sort_direction',
+        'display_order',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'sort_direction' => SortDirection::class,
+            'display_order' => 'integer',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<Event, $this>
+     */
+    public function event(): BelongsTo
+    {
+        return $this->belongsTo(Event::class);
+    }
+}

--- a/app/Models/EventScoreType.php
+++ b/app/Models/EventScoreType.php
@@ -20,7 +20,20 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $updated_at
  * @property-read Event $event
  *
- * @method static EventScoreTypeFactory factory($count = null, $state = [])
+ * @method static \Database\Factories\EventScoreTypeFactory factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventScoreType newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventScoreType newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventScoreType query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventScoreType whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventScoreType whereDisplayOrder($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventScoreType whereEventId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventScoreType whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventScoreType whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventScoreType whereSlug($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventScoreType whereSortDirection($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventScoreType whereUpdatedAt($value)
+ *
+ * @mixin \Eloquent
  */
 class EventScoreType extends Model
 {

--- a/app/Models/EventStanding.php
+++ b/app/Models/EventStanding.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\EventStandingFactory;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int $event_id
+ * @property int $event_attendee_id
+ * @property int $position
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Event $event
+ * @property-read EventAttendee $attendee
+ * @property-read Collection<int, EventStandingScore> $scores
+ *
+ * @method static EventStandingFactory factory($count = null, $state = [])
+ */
+class EventStanding extends Model
+{
+    /** @use HasFactory<EventStandingFactory> */
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'event_id',
+        'event_attendee_id',
+        'position',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'position' => 'integer',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<Event, $this>
+     */
+    public function event(): BelongsTo
+    {
+        return $this->belongsTo(Event::class);
+    }
+
+    /**
+     * @return BelongsTo<EventAttendee, $this>
+     */
+    public function attendee(): BelongsTo
+    {
+        return $this->belongsTo(EventAttendee::class, 'event_attendee_id');
+    }
+
+    /**
+     * @return HasMany<EventStandingScore, $this>
+     */
+    public function scores(): HasMany
+    {
+        return $this->hasMany(EventStandingScore::class);
+    }
+}

--- a/app/Models/EventStanding.php
+++ b/app/Models/EventStanding.php
@@ -17,11 +17,23 @@ use Illuminate\Support\Carbon;
  * @property int $position
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
- * @property-read Event $event
  * @property-read EventAttendee $attendee
+ * @property-read Event $event
  * @property-read Collection<int, EventStandingScore> $scores
+ * @property-read int|null $scores_count
  *
- * @method static EventStandingFactory factory($count = null, $state = [])
+ * @method static \Database\Factories\EventStandingFactory factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventStanding newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventStanding newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventStanding query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventStanding whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventStanding whereEventAttendeeId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventStanding whereEventId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventStanding whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventStanding wherePosition($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventStanding whereUpdatedAt($value)
+ *
+ * @mixin \Eloquent
  */
 class EventStanding extends Model
 {

--- a/app/Models/EventStandingScore.php
+++ b/app/Models/EventStandingScore.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\EventStandingScoreFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int $event_standing_id
+ * @property int $event_score_type_id
+ * @property string $value
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read EventStanding $standing
+ * @property-read EventScoreType $scoreType
+ *
+ * @method static EventStandingScoreFactory factory($count = null, $state = [])
+ */
+class EventStandingScore extends Model
+{
+    /** @use HasFactory<EventStandingScoreFactory> */
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'event_standing_id',
+        'event_score_type_id',
+        'value',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'value' => 'decimal:2',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<EventStanding, $this>
+     */
+    public function standing(): BelongsTo
+    {
+        return $this->belongsTo(EventStanding::class, 'event_standing_id');
+    }
+
+    /**
+     * @return BelongsTo<EventScoreType, $this>
+     */
+    public function scoreType(): BelongsTo
+    {
+        return $this->belongsTo(EventScoreType::class, 'event_score_type_id');
+    }
+}

--- a/app/Models/EventStandingScore.php
+++ b/app/Models/EventStandingScore.php
@@ -12,13 +12,24 @@ use Illuminate\Support\Carbon;
  * @property int $id
  * @property int $event_standing_id
  * @property int $event_score_type_id
- * @property string $value
+ * @property numeric $value
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
- * @property-read EventStanding $standing
  * @property-read EventScoreType $scoreType
+ * @property-read EventStanding $standing
  *
- * @method static EventStandingScoreFactory factory($count = null, $state = [])
+ * @method static \Database\Factories\EventStandingScoreFactory factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventStandingScore newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventStandingScore newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventStandingScore query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventStandingScore whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventStandingScore whereEventScoreTypeId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventStandingScore whereEventStandingId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventStandingScore whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventStandingScore whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventStandingScore whereValue($value)
+ *
+ * @mixin \Eloquent
  */
 class EventStandingScore extends Model
 {

--- a/app/Models/EventUpdate.php
+++ b/app/Models/EventUpdate.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\EventUpdateFactory;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int $event_id
+ * @property int $user_id
+ * @property string|null $title
+ * @property string $body
+ * @property Carbon|null $pinned_at
+ * @property Carbon $published_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Event $event
+ * @property-read User $author
+ * @property-read Collection<int, EventUpdateAttachment> $attachments
+ * @property-read int|null $attachments_count
+ *
+ * @method static \Database\Factories\EventUpdateFactory factory($count = null, $state = [])
+ *
+ * @mixin \Eloquent
+ */
+class EventUpdate extends Model
+{
+    /** @use HasFactory<EventUpdateFactory> */
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'event_id',
+        'user_id',
+        'title',
+        'body',
+        'pinned_at',
+        'published_at',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'pinned_at' => 'datetime',
+            'published_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<Event, $this>
+     */
+    public function event(): BelongsTo
+    {
+        return $this->belongsTo(Event::class);
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function author(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    /**
+     * @return HasMany<EventUpdateAttachment, $this>
+     */
+    public function attachments(): HasMany
+    {
+        return $this->hasMany(EventUpdateAttachment::class)->orderBy('display_order');
+    }
+}

--- a/app/Models/EventUpdate.php
+++ b/app/Models/EventUpdate.php
@@ -20,12 +20,24 @@ use Illuminate\Support\Carbon;
  * @property Carbon $published_at
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
- * @property-read Event $event
- * @property-read User $author
  * @property-read Collection<int, EventUpdateAttachment> $attachments
  * @property-read int|null $attachments_count
+ * @property-read User $author
+ * @property-read Event $event
  *
  * @method static \Database\Factories\EventUpdateFactory factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventUpdate newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventUpdate newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventUpdate query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventUpdate whereBody($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventUpdate whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventUpdate whereEventId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventUpdate whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventUpdate wherePinnedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventUpdate wherePublishedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventUpdate whereTitle($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventUpdate whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventUpdate whereUserId($value)
  *
  * @mixin \Eloquent
  */

--- a/app/Models/EventUpdateAttachment.php
+++ b/app/Models/EventUpdateAttachment.php
@@ -22,6 +22,16 @@ use Illuminate\Support\Facades\Storage;
  * @property-read string $url
  *
  * @method static \Database\Factories\EventUpdateAttachmentFactory factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventUpdateAttachment newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventUpdateAttachment newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventUpdateAttachment query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventUpdateAttachment whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventUpdateAttachment whereDisplayOrder($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventUpdateAttachment whereEventUpdateId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventUpdateAttachment whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventUpdateAttachment whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventUpdateAttachment wherePath($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventUpdateAttachment whereUpdatedAt($value)
  *
  * @mixin \Eloquent
  */

--- a/app/Models/EventUpdateAttachment.php
+++ b/app/Models/EventUpdateAttachment.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\EventUpdateAttachmentFactory;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * @property int $id
+ * @property int $event_update_id
+ * @property string $name
+ * @property string $path
+ * @property int $display_order
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read EventUpdate $eventUpdate
+ * @property-read string $url
+ *
+ * @method static \Database\Factories\EventUpdateAttachmentFactory factory($count = null, $state = [])
+ *
+ * @mixin \Eloquent
+ */
+class EventUpdateAttachment extends Model
+{
+    /** @use HasFactory<EventUpdateAttachmentFactory> */
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'event_update_id',
+        'name',
+        'path',
+        'display_order',
+    ];
+
+    /**
+     * @return BelongsTo<EventUpdate, $this>
+     */
+    public function eventUpdate(): BelongsTo
+    {
+        return $this->belongsTo(EventUpdate::class);
+    }
+
+    protected function url(): Attribute
+    {
+        return Attribute::get(fn (): string => Storage::disk('public')->url($this->path));
+    }
+}

--- a/app/Models/Faction.php
+++ b/app/Models/Faction.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\FactionFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int $game_system_id
+ * @property string $name
+ * @property string $slug
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read GameSystem $gameSystem
+ *
+ * @method static \Database\Factories\FactionFactory factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Faction newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Faction newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Faction query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Faction whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Faction whereGameSystemId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Faction whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Faction whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Faction whereSlug($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Faction whereUpdatedAt($value)
+ *
+ * @mixin \Eloquent
+ */
+class Faction extends Model
+{
+    /** @use HasFactory<FactionFactory> */
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'game_system_id',
+        'name',
+        'slug',
+    ];
+
+    /**
+     * @return BelongsTo<GameSystem, $this>
+     */
+    public function gameSystem(): BelongsTo
+    {
+        return $this->belongsTo(GameSystem::class);
+    }
+}

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -17,11 +17,23 @@ use Illuminate\Support\Carbon;
  * @property bool $is_bye
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
- * @property-read Round $round
- * @property-read Collection<int, EventAttendee> $attendees
  * @property-read GameAttendeePivot|null $pivot
+ * @property-read Collection<int, EventAttendee> $attendees
+ * @property-read int|null $attendees_count
+ * @property-read Round $round
  *
- * @method static GameFactory factory($count = null, $state = [])
+ * @method static \Database\Factories\GameFactory factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Game newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Game newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Game query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Game whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Game whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Game whereIsBye($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Game whereRoundId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Game whereTableNumber($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Game whereUpdatedAt($value)
+ *
+ * @mixin \Eloquent
  */
 class Game extends Model
 {

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\GameFactory;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int $round_id
+ * @property int|null $table_number
+ * @property bool $is_bye
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Round $round
+ * @property-read Collection<int, EventAttendee> $attendees
+ * @property-read GameAttendeePivot|null $pivot
+ *
+ * @method static GameFactory factory($count = null, $state = [])
+ */
+class Game extends Model
+{
+    /** @use HasFactory<GameFactory> */
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'round_id',
+        'table_number',
+        'is_bye',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'is_bye' => 'boolean',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<Round, $this>
+     */
+    public function round(): BelongsTo
+    {
+        return $this->belongsTo(Round::class);
+    }
+
+    /**
+     * @return BelongsToMany<EventAttendee, $this, GameAttendeePivot>
+     */
+    public function attendees(): BelongsToMany
+    {
+        return $this->belongsToMany(EventAttendee::class, 'game_attendee')
+            ->using(GameAttendeePivot::class)
+            ->withPivot('score')
+            ->withTimestamps();
+    }
+}

--- a/app/Models/GameAttendeePivot.php
+++ b/app/Models/GameAttendeePivot.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+/**
+ * @property int|null $score
+ */
+class GameAttendeePivot extends Pivot
+{
+    protected $table = 'game_attendee';
+}

--- a/app/Models/GameAttendeePivot.php
+++ b/app/Models/GameAttendeePivot.php
@@ -3,9 +3,27 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Support\Carbon;
 
 /**
+ * @property int $id
+ * @property int $game_id
+ * @property int $event_attendee_id
  * @property int|null $score
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|GameAttendeePivot newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|GameAttendeePivot newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|GameAttendeePivot query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|GameAttendeePivot whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|GameAttendeePivot whereEventAttendeeId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|GameAttendeePivot whereGameId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|GameAttendeePivot whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|GameAttendeePivot whereScore($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|GameAttendeePivot whereUpdatedAt($value)
+ *
+ * @mixin \Eloquent
  */
 class GameAttendeePivot extends Pivot
 {

--- a/app/Models/GameScore.php
+++ b/app/Models/GameScore.php
@@ -13,14 +13,26 @@ use Illuminate\Support\Carbon;
  * @property int $game_id
  * @property int $event_attendee_id
  * @property int $event_score_type_id
- * @property string $value
+ * @property numeric $value
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
- * @property-read Game $game
  * @property-read EventAttendee $attendee
+ * @property-read Game $game
  * @property-read EventScoreType $scoreType
  *
- * @method static GameScoreFactory factory($count = null, $state = [])
+ * @method static \Database\Factories\GameScoreFactory factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|GameScore newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|GameScore newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|GameScore query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|GameScore whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|GameScore whereEventAttendeeId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|GameScore whereEventScoreTypeId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|GameScore whereGameId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|GameScore whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|GameScore whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|GameScore whereValue($value)
+ *
+ * @mixin \Eloquent
  */
 class GameScore extends Model
 {

--- a/app/Models/GameScore.php
+++ b/app/Models/GameScore.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\GameScoreFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int $game_id
+ * @property int $event_attendee_id
+ * @property int $event_score_type_id
+ * @property string $value
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Game $game
+ * @property-read EventAttendee $attendee
+ * @property-read EventScoreType $scoreType
+ *
+ * @method static GameScoreFactory factory($count = null, $state = [])
+ */
+class GameScore extends Model
+{
+    /** @use HasFactory<GameScoreFactory> */
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'game_id',
+        'event_attendee_id',
+        'event_score_type_id',
+        'value',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'value' => 'decimal:2',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<Game, $this>
+     */
+    public function game(): BelongsTo
+    {
+        return $this->belongsTo(Game::class);
+    }
+
+    /**
+     * @return BelongsTo<EventAttendee, $this>
+     */
+    public function attendee(): BelongsTo
+    {
+        return $this->belongsTo(EventAttendee::class, 'event_attendee_id');
+    }
+
+    /**
+     * @return BelongsTo<EventScoreType, $this>
+     */
+    public function scoreType(): BelongsTo
+    {
+        return $this->belongsTo(EventScoreType::class, 'event_score_type_id');
+    }
+}

--- a/app/Models/GameSystem.php
+++ b/app/Models/GameSystem.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\GameSystemFactory;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $slug
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Collection<int, Event> $events
+ * @property-read int|null $events_count
+ * @property-read Collection<int, Faction> $factions
+ * @property-read int|null $factions_count
+ *
+ * @method static \Database\Factories\GameSystemFactory factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|GameSystem newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|GameSystem newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|GameSystem query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|GameSystem whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|GameSystem whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|GameSystem whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|GameSystem whereSlug($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|GameSystem whereUpdatedAt($value)
+ *
+ * @mixin \Eloquent
+ */
+class GameSystem extends Model
+{
+    /** @use HasFactory<GameSystemFactory> */
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+        'slug',
+    ];
+
+    public function getRouteKeyName(): string
+    {
+        return 'slug';
+    }
+
+    /**
+     * @return HasMany<Faction, $this>
+     */
+    public function factions(): HasMany
+    {
+        return $this->hasMany(Faction::class);
+    }
+
+    /**
+     * @return HasMany<Event, $this>
+     */
+    public function events(): HasMany
+    {
+        return $this->hasMany(Event::class);
+    }
+}

--- a/app/Models/Photo.php
+++ b/app/Models/Photo.php
@@ -21,6 +21,8 @@ use Illuminate\Support\Facades\Storage;
  * @property string|null $thumbnail_path
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
+ * @property int|null $event_id
+ * @property-read Event|null $event
  * @property-read Collection<int, Reaction> $reactions
  * @property-read int|null $reactions_count
  * @property-read string|null $thumbnail_url
@@ -33,6 +35,7 @@ use Illuminate\Support\Facades\Storage;
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Photo query()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Photo whereCreatedAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Photo whereDescription($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Photo whereEventId($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Photo whereId($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Photo whereName($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Photo wherePath($value)
@@ -59,7 +62,16 @@ class Photo extends Model
         'path',
         'thumbnail_path',
         'user_id',
+        'event_id',
     ];
+
+    /**
+     * @return BelongsTo<Event, $this>
+     */
+    public function event(): BelongsTo
+    {
+        return $this->belongsTo(Event::class);
+    }
 
     /**
      * @return BelongsTo<User, $this>

--- a/app/Models/Round.php
+++ b/app/Models/Round.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\RoundFactory;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int $event_id
+ * @property int $number
+ * @property string|null $name
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Event $event
+ * @property-read Collection<int, Game> $games
+ *
+ * @method static RoundFactory factory($count = null, $state = [])
+ */
+class Round extends Model
+{
+    /** @use HasFactory<RoundFactory> */
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'event_id',
+        'number',
+        'name',
+    ];
+
+    /**
+     * @return BelongsTo<Event, $this>
+     */
+    public function event(): BelongsTo
+    {
+        return $this->belongsTo(Event::class);
+    }
+
+    /**
+     * @return HasMany<Game, $this>
+     */
+    public function games(): HasMany
+    {
+        return $this->hasMany(Game::class);
+    }
+}

--- a/app/Models/Round.php
+++ b/app/Models/Round.php
@@ -19,8 +19,20 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $updated_at
  * @property-read Event $event
  * @property-read Collection<int, Game> $games
+ * @property-read int|null $games_count
  *
- * @method static RoundFactory factory($count = null, $state = [])
+ * @method static \Database\Factories\RoundFactory factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Round newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Round newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Round query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Round whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Round whereEventId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Round whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Round whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Round whereNumber($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Round whereUpdatedAt($value)
+ *
+ * @mixin \Eloquent
  */
 class Round extends Model
 {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -41,6 +41,8 @@ use Laravel\Sanctum\PersonalAccessToken;
  * @property-read int|null $blocked_by_count
  * @property-read Collection<int, User> $blockedUsers
  * @property-read int|null $blocked_users_count
+ * @property-read Collection<int, Club> $clubs
+ * @property-read int|null $clubs_count
  * @property-read Collection<int, Conversation> $conversations
  * @property-read int|null $conversations_count
  * @property-read Collection<int, User> $followers
@@ -211,6 +213,22 @@ class User extends Authenticatable implements MustVerifyEmail
     public function photos(): HasMany
     {
         return $this->hasMany(Photo::class);
+    }
+
+    /**
+     * @return BelongsToMany<Club, $this>
+     */
+    public function clubs(): BelongsToMany
+    {
+        return $this->belongsToMany(Club::class)->withTimestamps();
+    }
+
+    /**
+     * @return HasMany<EventAttendee, $this>
+     */
+    public function eventAttendees(): HasMany
+    {
+        return $this->hasMany(EventAttendee::class);
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -45,6 +45,8 @@ use Laravel\Sanctum\PersonalAccessToken;
  * @property-read int|null $clubs_count
  * @property-read Collection<int, Conversation> $conversations
  * @property-read int|null $conversations_count
+ * @property-read Collection<int, EventAttendee> $eventAttendees
+ * @property-read int|null $event_attendees_count
  * @property-read Collection<int, User> $followers
  * @property-read int|null $followers_count
  * @property-read Collection<int, User> $following

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -19,6 +19,7 @@ return Application::configure(basePath: dirname(__DIR__))
                     __DIR__.'/../routes/api/users.php',
                     __DIR__.'/../routes/api/gallery.php',
                     __DIR__.'/../routes/api/conversations.php',
+                    __DIR__.'/../routes/api/events.php',
                 ]);
         },
     )

--- a/database/factories/ClubFactory.php
+++ b/database/factories/ClubFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\Country;
+use App\Models\Club;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Club>
+ */
+class ClubFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $name = fake()->unique()->company();
+
+        return [
+            'name' => $name,
+            'slug' => Str::slug($name).'-'.fake()->unique()->numberBetween(1, 100000),
+            'city' => fake()->city(),
+            'country' => fake()->randomElement(Country::cases())->value,
+        ];
+    }
+}

--- a/database/factories/EventAttendeeFactory.php
+++ b/database/factories/EventAttendeeFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Event;
+use App\Models\EventAttendee;
+use App\Models\Faction;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<EventAttendee>
+ */
+class EventAttendeeFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'event_id' => Event::factory(),
+            'user_id' => User::factory(),
+            'faction_id' => Faction::factory(),
+            'army_list' => fake()->paragraph(),
+            'checked_in_at' => null,
+        ];
+    }
+}

--- a/database/factories/EventCustomFieldFactory.php
+++ b/database/factories/EventCustomFieldFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\CustomFieldType;
+use App\Models\Event;
+use App\Models\EventCustomField;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<EventCustomField>
+ */
+class EventCustomFieldFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'event_id' => Event::factory(),
+            'name' => fake()->words(2, true),
+            'type' => CustomFieldType::Text,
+            'options' => null,
+            'display_order' => 0,
+        ];
+    }
+}

--- a/database/factories/EventCustomFieldResponseFactory.php
+++ b/database/factories/EventCustomFieldResponseFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\EventAttendee;
+use App\Models\EventCustomField;
+use App\Models\EventCustomFieldResponse;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<EventCustomFieldResponse>
+ */
+class EventCustomFieldResponseFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'event_attendee_id' => EventAttendee::factory(),
+            'event_custom_field_id' => EventCustomField::factory(),
+            'value' => fake()->sentence(),
+        ];
+    }
+}

--- a/database/factories/EventDocumentFactory.php
+++ b/database/factories/EventDocumentFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Event;
+use App\Models\EventDocument;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<EventDocument>
+ */
+class EventDocumentFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'event_id' => Event::factory(),
+            'name' => fake()->words(3, true),
+            'path' => 'events/documents/'.fake()->uuid().'.pdf',
+        ];
+    }
+}

--- a/database/factories/EventFactory.php
+++ b/database/factories/EventFactory.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\Country;
+use App\Enums\EventStatus;
+use App\Enums\PairingFormat;
+use App\Models\Event;
+use App\Models\GameSystem;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Event>
+ */
+class EventFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $name = fake()->unique()->sentence(3);
+        $starts = fake()->dateTimeBetween('+1 week', '+6 months');
+        $ends = (clone $starts)->modify('+2 days');
+
+        return [
+            'game_system_id' => GameSystem::factory(),
+            'club_id' => null,
+            'name' => rtrim($name, '.'),
+            'slug' => Str::slug($name).'-'.fake()->unique()->numberBetween(1, 100000),
+            'description' => fake()->paragraph(),
+            'status' => EventStatus::Draft,
+            'pairing_format' => PairingFormat::Swiss,
+            'starts_at' => $starts,
+            'ends_at' => $ends,
+            'venue_name' => fake()->company().' Hall',
+            'venue_address' => fake()->streetAddress(),
+            'venue_city' => fake()->city(),
+            'venue_country' => fake()->randomElement(Country::cases())->value,
+            'max_attendees' => fake()->numberBetween(16, 128),
+        ];
+    }
+
+    public function draft(): self
+    {
+        return $this->state(fn (): array => ['status' => EventStatus::Draft]);
+    }
+
+    public function published(): self
+    {
+        return $this->state(fn (): array => ['status' => EventStatus::Published]);
+    }
+
+    public function active(): self
+    {
+        return $this->state(fn (): array => ['status' => EventStatus::Active]);
+    }
+
+    public function completed(): self
+    {
+        return $this->state(fn (): array => ['status' => EventStatus::Completed]);
+    }
+
+    public function cancelled(): self
+    {
+        return $this->state(fn (): array => ['status' => EventStatus::Cancelled]);
+    }
+}

--- a/database/factories/EventFactory.php
+++ b/database/factories/EventFactory.php
@@ -66,4 +66,9 @@ class EventFactory extends Factory
     {
         return $this->state(fn (): array => ['status' => EventStatus::Cancelled]);
     }
+
+    public function standingsVisible(): self
+    {
+        return $this->state(fn (): array => ['standings_visible' => true]);
+    }
 }

--- a/database/factories/EventScoreTypeFactory.php
+++ b/database/factories/EventScoreTypeFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\SortDirection;
+use App\Models\Event;
+use App\Models\EventScoreType;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<EventScoreType>
+ */
+class EventScoreTypeFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $name = fake()->unique()->randomElement(['Battle Points', 'VP Difference', 'Sportsmanship', 'Painting Score', 'Best Army']);
+
+        return [
+            'event_id' => Event::factory(),
+            'name' => $name,
+            'slug' => Str::slug($name),
+            'sort_direction' => SortDirection::Desc,
+            'display_order' => 0,
+        ];
+    }
+}

--- a/database/factories/EventStandingFactory.php
+++ b/database/factories/EventStandingFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Event;
+use App\Models\EventAttendee;
+use App\Models\EventStanding;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<EventStanding>
+ */
+class EventStandingFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'event_id' => Event::factory(),
+            'event_attendee_id' => EventAttendee::factory(),
+            'position' => fake()->numberBetween(1, 100),
+        ];
+    }
+}

--- a/database/factories/EventStandingScoreFactory.php
+++ b/database/factories/EventStandingScoreFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\EventScoreType;
+use App\Models\EventStanding;
+use App\Models\EventStandingScore;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<EventStandingScore>
+ */
+class EventStandingScoreFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'event_standing_id' => EventStanding::factory(),
+            'event_score_type_id' => EventScoreType::factory(),
+            'value' => fake()->randomFloat(2, 0, 100),
+        ];
+    }
+}

--- a/database/factories/EventUpdateAttachmentFactory.php
+++ b/database/factories/EventUpdateAttachmentFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\EventUpdate;
+use App\Models\EventUpdateAttachment;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<EventUpdateAttachment>
+ */
+class EventUpdateAttachmentFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'event_update_id' => EventUpdate::factory(),
+            'name' => fake()->words(3, true),
+            'path' => 'events/updates/'.fake()->uuid().'.pdf',
+            'display_order' => 0,
+        ];
+    }
+}

--- a/database/factories/EventUpdateFactory.php
+++ b/database/factories/EventUpdateFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Event;
+use App\Models\EventUpdate;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<EventUpdate>
+ */
+class EventUpdateFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'event_id' => Event::factory(),
+            'user_id' => User::factory(),
+            'title' => rtrim(fake()->sentence(4), '.'),
+            'body' => fake()->paragraphs(2, true),
+            'pinned_at' => null,
+            'published_at' => fake()->dateTimeBetween('-1 month', 'now'),
+        ];
+    }
+
+    public function pinned(): self
+    {
+        return $this->state(fn (): array => ['pinned_at' => now()]);
+    }
+}

--- a/database/factories/FactionFactory.php
+++ b/database/factories/FactionFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Faction;
+use App\Models\GameSystem;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Faction>
+ */
+class FactionFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $name = fake()->unique()->words(2, true);
+
+        return [
+            'game_system_id' => GameSystem::factory(),
+            'name' => ucwords($name),
+            'slug' => Str::slug($name).'-'.fake()->unique()->numberBetween(1, 100000),
+        ];
+    }
+}

--- a/database/factories/GameFactory.php
+++ b/database/factories/GameFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Game;
+use App\Models\Round;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Game>
+ */
+class GameFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'round_id' => Round::factory(),
+            'table_number' => fake()->numberBetween(1, 20),
+            'is_bye' => false,
+        ];
+    }
+
+    public function bye(): self
+    {
+        return $this->state(fn (): array => ['is_bye' => true]);
+    }
+}

--- a/database/factories/GameScoreFactory.php
+++ b/database/factories/GameScoreFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\EventAttendee;
+use App\Models\EventScoreType;
+use App\Models\Game;
+use App\Models\GameScore;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<GameScore>
+ */
+class GameScoreFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'game_id' => Game::factory(),
+            'event_attendee_id' => EventAttendee::factory(),
+            'event_score_type_id' => EventScoreType::factory(),
+            'value' => fake()->randomFloat(2, 0, 100),
+        ];
+    }
+}

--- a/database/factories/GameSystemFactory.php
+++ b/database/factories/GameSystemFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\GameSystem;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<GameSystem>
+ */
+class GameSystemFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $name = fake()->unique()->words(2, true);
+
+        return [
+            'name' => ucwords($name),
+            'slug' => Str::slug($name).'-'.fake()->unique()->numberBetween(1, 100000),
+        ];
+    }
+}

--- a/database/factories/RoundFactory.php
+++ b/database/factories/RoundFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Event;
+use App\Models\Round;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Round>
+ */
+class RoundFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'event_id' => Event::factory(),
+            'number' => fake()->numberBetween(1, 6),
+            'name' => null,
+        ];
+    }
+}

--- a/database/migrations/2026_04_12_204800_create_game_systems_table.php
+++ b/database/migrations/2026_04_12_204800_create_game_systems_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('game_systems', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('game_systems');
+    }
+};

--- a/database/migrations/2026_04_12_204801_create_factions_table.php
+++ b/database/migrations/2026_04_12_204801_create_factions_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('factions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('game_system_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->string('slug');
+            $table->timestamps();
+
+            $table->unique(['game_system_id', 'slug']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('factions');
+    }
+};

--- a/database/migrations/2026_04_12_204802_create_clubs_table.php
+++ b/database/migrations/2026_04_12_204802_create_clubs_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('clubs', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->string('city')->nullable();
+            $table->string('country', 2)->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('clubs');
+    }
+};

--- a/database/migrations/2026_04_12_204803_create_club_user_table.php
+++ b/database/migrations/2026_04_12_204803_create_club_user_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('club_user', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('club_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->unique(['club_id', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('club_user');
+    }
+};

--- a/database/migrations/2026_04_12_204804_create_events_table.php
+++ b/database/migrations/2026_04_12_204804_create_events_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('events', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('game_system_id')->constrained()->restrictOnDelete();
+            $table->foreignId('club_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->text('description')->nullable();
+            $table->string('status')->default('draft');
+            $table->string('pairing_format')->default('swiss');
+            $table->dateTime('starts_at');
+            $table->dateTime('ends_at');
+            $table->string('venue_name')->nullable();
+            $table->string('venue_address')->nullable();
+            $table->string('venue_city')->nullable();
+            $table->string('venue_country', 2)->nullable();
+            $table->unsignedInteger('max_attendees')->nullable();
+            $table->timestamps();
+
+            $table->index('status');
+            $table->index('starts_at');
+            $table->index('game_system_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('events');
+    }
+};

--- a/database/migrations/2026_04_12_204805_create_event_documents_table.php
+++ b/database/migrations/2026_04_12_204805_create_event_documents_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('event_documents', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('event_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->string('path');
+            $table->timestamps();
+
+            $table->index('event_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('event_documents');
+    }
+};

--- a/database/migrations/2026_04_12_212706_create_event_updates_table.php
+++ b/database/migrations/2026_04_12_212706_create_event_updates_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('event_updates', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('event_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('title')->nullable();
+            $table->text('body');
+            $table->timestamp('pinned_at')->nullable();
+            $table->timestamp('published_at');
+            $table->timestamps();
+
+            $table->index(['event_id', 'pinned_at', 'published_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('event_updates');
+    }
+};

--- a/database/migrations/2026_04_12_212707_create_event_update_attachments_table.php
+++ b/database/migrations/2026_04_12_212707_create_event_update_attachments_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('event_update_attachments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('event_update_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->string('path');
+            $table->unsignedInteger('display_order')->default(0);
+            $table->timestamps();
+
+            $table->index(['event_update_id', 'display_order']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('event_update_attachments');
+    }
+};

--- a/database/migrations/2026_04_12_214946_create_event_attendees_table.php
+++ b/database/migrations/2026_04_12_214946_create_event_attendees_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('event_attendees', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('event_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('faction_id')->nullable()->constrained()->nullOnDelete();
+            $table->text('army_list')->nullable();
+            $table->timestamp('checked_in_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['event_id', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('event_attendees');
+    }
+};

--- a/database/migrations/2026_04_12_220845_create_event_custom_fields_table.php
+++ b/database/migrations/2026_04_12_220845_create_event_custom_fields_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('event_custom_fields', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('event_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->string('type');
+            $table->json('options')->nullable();
+            $table->unsignedInteger('display_order')->default(0);
+            $table->timestamps();
+
+            $table->index(['event_id', 'display_order']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('event_custom_fields');
+    }
+};

--- a/database/migrations/2026_04_12_220846_create_event_custom_field_responses_table.php
+++ b/database/migrations/2026_04_12_220846_create_event_custom_field_responses_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('event_custom_field_responses', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('event_attendee_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('event_custom_field_id')->constrained()->cascadeOnDelete();
+            $table->text('value')->nullable();
+            $table->timestamps();
+
+            $table->unique(['event_attendee_id', 'event_custom_field_id'], 'attendee_field_unique');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('event_custom_field_responses');
+    }
+};

--- a/database/migrations/2026_04_20_225442_create_rounds_table.php
+++ b/database/migrations/2026_04_20_225442_create_rounds_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('rounds', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('event_id')->constrained()->cascadeOnDelete();
+            $table->unsignedSmallInteger('number');
+            $table->string('name')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('rounds');
+    }
+};

--- a/database/migrations/2026_04_20_225612_create_games_table.php
+++ b/database/migrations/2026_04_20_225612_create_games_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('games', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('round_id')->constrained()->cascadeOnDelete();
+            $table->unsignedSmallInteger('table_number')->nullable();
+            $table->boolean('is_bye')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('games');
+    }
+};

--- a/database/migrations/2026_04_20_225615_create_game_attendee_table.php
+++ b/database/migrations/2026_04_20_225615_create_game_attendee_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('game_attendee', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('game_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('event_attendee_id')->constrained()->cascadeOnDelete();
+            $table->integer('score')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('game_attendee');
+    }
+};

--- a/database/migrations/2026_04_20_231347_add_standings_visible_to_events_table.php
+++ b/database/migrations/2026_04_20_231347_add_standings_visible_to_events_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->boolean('standings_visible')->default(false)->after('max_attendees');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->dropColumn('standings_visible');
+        });
+    }
+};

--- a/database/migrations/2026_04_20_231410_create_event_score_types_table.php
+++ b/database/migrations/2026_04_20_231410_create_event_score_types_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('event_score_types', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('event_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->string('slug');
+            $table->string('sort_direction')->default('desc');
+            $table->unsignedSmallInteger('display_order')->default(0);
+            $table->timestamps();
+
+            $table->unique(['event_id', 'slug']);
+            $table->index(['event_id', 'display_order']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('event_score_types');
+    }
+};

--- a/database/migrations/2026_04_20_231411_create_game_scores_table.php
+++ b/database/migrations/2026_04_20_231411_create_game_scores_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('game_scores', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('game_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('event_attendee_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('event_score_type_id')->constrained()->cascadeOnDelete();
+            $table->decimal('value', 10, 2)->default(0);
+            $table->timestamps();
+
+            $table->unique(['game_id', 'event_attendee_id', 'event_score_type_id'], 'game_scores_unique');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('game_scores');
+    }
+};

--- a/database/migrations/2026_04_20_231412_create_event_standings_table.php
+++ b/database/migrations/2026_04_20_231412_create_event_standings_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('event_standings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('event_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('event_attendee_id')->constrained()->cascadeOnDelete();
+            $table->unsignedInteger('position');
+            $table->timestamps();
+
+            $table->unique(['event_id', 'event_attendee_id']);
+            $table->index(['event_id', 'position']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('event_standings');
+    }
+};

--- a/database/migrations/2026_04_20_231413_create_event_standing_scores_table.php
+++ b/database/migrations/2026_04_20_231413_create_event_standing_scores_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('event_standing_scores', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('event_standing_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('event_score_type_id')->constrained()->cascadeOnDelete();
+            $table->decimal('value', 10, 2)->default(0);
+            $table->timestamps();
+
+            $table->unique(['event_standing_id', 'event_score_type_id'], 'standing_scores_unique');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('event_standing_scores');
+    }
+};

--- a/database/migrations/2026_04_21_220922_add_event_id_to_photos_table.php
+++ b/database/migrations/2026_04_21_220922_add_event_id_to_photos_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('photos', function (Blueprint $table) {
+            $table->foreignId('event_id')->nullable()->constrained()->nullOnDelete();
+            $table->index('event_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('photos', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('event_id');
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -21,5 +21,7 @@ class DatabaseSeeder extends Seeder
             'name' => 'Test User',
             'email' => 'test@example.com',
         ]);
+
+        $this->call(EventSeeder::class);
     }
 }

--- a/database/seeders/EventSeeder.php
+++ b/database/seeders/EventSeeder.php
@@ -1,0 +1,390 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\CustomFieldType;
+use App\Enums\SortDirection;
+use App\Models\Club;
+use App\Models\Event;
+use App\Models\EventAttendee;
+use App\Models\EventCustomField;
+use App\Models\EventCustomFieldResponse;
+use App\Models\EventDocument;
+use App\Models\EventScoreType;
+use App\Models\EventStanding;
+use App\Models\EventStandingScore;
+use App\Models\EventUpdate;
+use App\Models\EventUpdateAttachment;
+use App\Models\Faction;
+use App\Models\Game;
+use App\Models\GameScore;
+use App\Models\GameSystem;
+use App\Models\Photo;
+use App\Models\Reaction;
+use App\Models\Round;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class EventSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $gameSystems = $this->createGameSystems();
+        $clubs = $this->createClubs();
+        $users = $this->createUsers($clubs);
+
+        $this->createDraftEvent($gameSystems[0], $clubs[0], $users);
+        $this->createPublishedEvent($gameSystems[1], $clubs[1], $users);
+        $this->createActiveEvent($gameSystems[0], $clubs[0], $users);
+        $this->createCompletedEvent($gameSystems[1], $clubs[2], $users);
+        $this->createCancelledEvent($gameSystems[0], null, $users);
+    }
+
+    /**
+     * @return list<GameSystem>
+     */
+    private function createGameSystems(): array
+    {
+        return [
+            $this->createGameSystemWithFactions('Warhammer 40,000', [
+                'Space Marines', 'Orks', 'Aeldari', 'Tyranids', 'Necrons', 'Chaos Space Marines',
+            ]),
+            $this->createGameSystemWithFactions('Age of Sigmar', [
+                'Stormcast Eternals', 'Skaven', 'Lumineth Realm-lords', 'Orruk Warclans',
+            ]),
+        ];
+    }
+
+    private function createGameSystemWithFactions(string $name, array $factionNames): GameSystem
+    {
+        $system = GameSystem::factory()->create(['name' => $name, 'slug' => str($name)->slug()]);
+
+        foreach ($factionNames as $factionName) {
+            Faction::factory()->for($system)->create([
+                'name' => $factionName,
+                'slug' => str($factionName)->slug(),
+            ]);
+        }
+
+        return $system;
+    }
+
+    /**
+     * @return list<Club>
+     */
+    private function createClubs(): array
+    {
+        return [
+            Club::factory()->create(['name' => 'London Warlords', 'slug' => 'london-warlords', 'city' => 'London']),
+            Club::factory()->create(['name' => 'Manchester Maulers', 'slug' => 'manchester-maulers', 'city' => 'Manchester']),
+            Club::factory()->create(['name' => 'Bristol Berserkers', 'slug' => 'bristol-berserkers', 'city' => 'Bristol']),
+        ];
+    }
+
+    /**
+     * @return list<User>
+     */
+    private function createUsers(array $clubs): array
+    {
+        $users = User::factory()->count(20)->create();
+
+        foreach ($clubs as $club) {
+            $club->members()->attach($users->random(rand(4, 8))->pluck('id'));
+        }
+
+        return $users->all();
+    }
+
+    private function createDraftEvent(GameSystem $system, Club $club, array $users): void
+    {
+        Event::factory()->draft()->for($system)->for($club)->create([
+            'name' => 'Summer Showdown 2026',
+            'slug' => 'summer-showdown-2026',
+            'venue_name' => 'Warhammer World',
+            'venue_city' => 'Nottingham',
+            'starts_at' => now()->addMonths(3),
+            'ends_at' => now()->addMonths(3)->addDay(),
+        ]);
+    }
+
+    private function createPublishedEvent(GameSystem $system, Club $club, array $users): void
+    {
+        $event = Event::factory()->published()->for($system)->for($club)->create([
+            'name' => 'Northern Crusade',
+            'slug' => 'northern-crusade',
+            'venue_name' => 'Manchester Convention Centre',
+            'venue_city' => 'Manchester',
+            'starts_at' => now()->addMonth(),
+            'ends_at' => now()->addMonth()->addDay(),
+        ]);
+
+        $this->addDocuments($event);
+        $this->addCustomFields($event);
+    }
+
+    private function createActiveEvent(GameSystem $system, Club $club, array $users): void
+    {
+        $event = Event::factory()->active()->standingsVisible()->for($system)->for($club)->create([
+            'name' => 'London Grand Tournament',
+            'slug' => 'london-grand-tournament',
+            'venue_name' => 'ExCeL London',
+            'venue_city' => 'London',
+            'max_attendees' => 32,
+            'starts_at' => now()->subDay(),
+            'ends_at' => now()->addDay(),
+        ]);
+
+        $factions = $system->factions;
+        $attendees = collect($users)->take(16)->map(fn (User $user) => EventAttendee::factory()
+            ->for($event)
+            ->for($user)
+            ->for($factions->random())
+            ->create(['checked_in_at' => now()->subDay()])
+        );
+
+        $scoreTypes = $this->addScoreTypes($event);
+        $this->addCustomFields($event);
+        $this->addCustomFieldResponses($event, $attendees);
+        $this->addDocuments($event);
+        $this->addUpdates($event, $users);
+        $this->addPhotos($event, $users);
+
+        $round1 = Round::factory()->for($event)->create(['number' => 1, 'name' => 'Round 1']);
+        $this->createGamesForRound($round1, $attendees, $scoreTypes);
+
+        $round2 = Round::factory()->for($event)->create(['number' => 2, 'name' => 'Round 2']);
+        $this->createGamesForRound($round2, $attendees, $scoreTypes);
+
+        Round::factory()->for($event)->create(['number' => 3, 'name' => 'Round 3']);
+
+        $this->createPartialStandings($event, $attendees, $scoreTypes);
+    }
+
+    private function createCompletedEvent(GameSystem $system, Club $club, array $users): void
+    {
+        $event = Event::factory()->completed()->standingsVisible()->for($system)->for($club)->create([
+            'name' => 'Bristol Bash 2025',
+            'slug' => 'bristol-bash-2025',
+            'venue_name' => 'Colston Hall',
+            'venue_city' => 'Bristol',
+            'max_attendees' => 24,
+            'starts_at' => now()->subWeeks(2),
+            'ends_at' => now()->subWeeks(2)->addDay(),
+        ]);
+
+        $factions = $system->factions;
+        $attendees = collect($users)->take(12)->map(fn (User $user) => EventAttendee::factory()
+            ->for($event)
+            ->for($user)
+            ->for($factions->random())
+            ->create(['checked_in_at' => now()->subWeeks(2)])
+        );
+
+        $scoreTypes = $this->addScoreTypes($event);
+        $this->addDocuments($event);
+        $this->addUpdates($event, $users);
+        $this->addPhotos($event, $users);
+
+        foreach (range(1, 3) as $number) {
+            $round = Round::factory()->for($event)->create(['number' => $number, 'name' => "Round {$number}"]);
+            $this->createGamesForRound($round, $attendees, $scoreTypes);
+        }
+
+        $this->createFullStandings($event, $attendees, $scoreTypes);
+    }
+
+    private function createCancelledEvent(GameSystem $system, ?Club $club, array $users): void
+    {
+        Event::factory()->cancelled()->for($system)->create([
+            'name' => 'Cancelled Cup',
+            'slug' => 'cancelled-cup',
+            'venue_name' => 'Village Hall',
+            'venue_city' => 'Oxford',
+            'starts_at' => now()->addWeek(),
+            'ends_at' => now()->addWeek()->addDay(),
+        ]);
+    }
+
+    /**
+     * @return list<EventScoreType>
+     */
+    private function addScoreTypes(Event $event): array
+    {
+        return [
+            EventScoreType::factory()->for($event)->create([
+                'name' => 'Battle Points',
+                'slug' => 'battle-points',
+                'sort_direction' => SortDirection::Desc,
+                'display_order' => 0,
+            ]),
+            EventScoreType::factory()->for($event)->create([
+                'name' => 'Sportsmanship',
+                'slug' => 'sportsmanship',
+                'sort_direction' => SortDirection::Desc,
+                'display_order' => 1,
+            ]),
+        ];
+    }
+
+    private function addDocuments(Event $event): void
+    {
+        EventDocument::factory()->for($event)->create(['name' => 'Players Pack']);
+        EventDocument::factory()->for($event)->create(['name' => 'Rules FAQ']);
+    }
+
+    private function addCustomFields(Event $event): void
+    {
+        EventCustomField::factory()->for($event)->create([
+            'name' => 'Team Name',
+            'type' => CustomFieldType::Text,
+            'display_order' => 0,
+        ]);
+        EventCustomField::factory()->for($event)->create([
+            'name' => 'Experience Level',
+            'type' => CustomFieldType::Select,
+            'options' => ['Beginner', 'Intermediate', 'Advanced', 'Veteran'],
+            'display_order' => 1,
+        ]);
+        EventCustomField::factory()->for($event)->create([
+            'name' => 'Bringing Display Board',
+            'type' => CustomFieldType::Checkbox,
+            'display_order' => 2,
+        ]);
+    }
+
+    private function addCustomFieldResponses(Event $event, $attendees): void
+    {
+        $fields = EventCustomField::query()->where('event_id', $event->id)->get();
+
+        foreach ($attendees as $attendee) {
+            foreach ($fields as $field) {
+                $value = match ($field->type) {
+                    CustomFieldType::Text => fake()->words(2, true),
+                    CustomFieldType::Select => fake()->randomElement($field->options ?? ['N/A']),
+                    CustomFieldType::Checkbox => fake()->boolean() ? '1' : '0',
+                    default => fake()->word(),
+                };
+
+                EventCustomFieldResponse::factory()
+                    ->for($attendee, 'attendee')
+                    ->for($field, 'field')
+                    ->create(['value' => $value]);
+            }
+        }
+    }
+
+    private function addUpdates(Event $event, array $users): void
+    {
+        EventUpdate::factory()->pinned()->for($event)->for($users[0], 'author')->create([
+            'title' => 'Welcome to '.$event->name,
+            'body' => 'We are excited to welcome everyone to this event. Please check the documents section for the players pack.',
+        ]);
+
+        $update = EventUpdate::factory()->for($event)->for($users[1], 'author')->create([
+            'title' => 'Round 1 Pairings Posted',
+            'body' => 'Round 1 pairings are now live. Please check your table assignments.',
+        ]);
+
+        EventUpdateAttachment::factory()->for($update)->create(['name' => 'Round 1 Pairings.pdf']);
+
+        EventUpdate::factory()->for($event)->for($users[0], 'author')->create([
+            'title' => 'Lunch Break',
+            'body' => 'Lunch will be served in the main hall from 12:00 to 13:00.',
+        ]);
+    }
+
+    private function addPhotos(Event $event, array $users): void
+    {
+        $photos = collect($users)->take(6)->map(fn (User $user) => Photo::factory()->for($user)->create(['event_id' => $event->id])
+        );
+
+        foreach ($photos->take(4) as $photo) {
+            $reactingUsers = collect($users)->random(rand(1, 5));
+            foreach ($reactingUsers as $user) {
+                Reaction::factory()->for($photo, 'reactable')->create(['user_id' => $user->id]);
+            }
+        }
+    }
+
+    private function createGamesForRound(Round $round, $attendees, array $scoreTypes): void
+    {
+        $shuffled = $attendees->shuffle();
+        $pairs = $shuffled->chunk(2);
+
+        $tableNumber = 1;
+        foreach ($pairs as $pair) {
+            $players = $pair->values();
+
+            if ($players->count() === 1) {
+                $game = Game::factory()->bye()->for($round)->create(['table_number' => $tableNumber]);
+                $game->attendees()->attach($players[0]->id, ['score' => 20]);
+
+                foreach ($scoreTypes as $scoreType) {
+                    GameScore::factory()->create([
+                        'game_id' => $game->id,
+                        'event_attendee_id' => $players[0]->id,
+                        'event_score_type_id' => $scoreType->id,
+                        'value' => 10,
+                    ]);
+                }
+            } else {
+                $game = Game::factory()->for($round)->create(['table_number' => $tableNumber]);
+
+                $score1 = fake()->numberBetween(0, 20);
+                $score2 = 20 - $score1;
+
+                $game->attendees()->attach($players[0]->id, ['score' => $score1]);
+                $game->attendees()->attach($players[1]->id, ['score' => $score2]);
+
+                foreach ([[$players[0], $score1], [$players[1], $score2]] as [$player, $score]) {
+                    foreach ($scoreTypes as $index => $scoreType) {
+                        $value = $index === 0 ? $score : fake()->numberBetween(1, 5);
+                        GameScore::factory()->create([
+                            'game_id' => $game->id,
+                            'event_attendee_id' => $player->id,
+                            'event_score_type_id' => $scoreType->id,
+                            'value' => $value,
+                        ]);
+                    }
+                }
+            }
+
+            $tableNumber++;
+        }
+    }
+
+    private function createPartialStandings(Event $event, $attendees, array $scoreTypes): void
+    {
+        $primaryScoreType = $scoreTypes[0];
+
+        $sorted = $attendees->sortByDesc(fn ($a) => GameScore::query()
+            ->where('event_attendee_id', $a->id)
+            ->where('event_score_type_id', $primaryScoreType->id)
+            ->sum('value')
+        )->values();
+
+        foreach ($sorted as $position => $attendee) {
+            $standing = EventStanding::factory()->for($event)->create([
+                'event_attendee_id' => $attendee->id,
+                'position' => $position + 1,
+            ]);
+
+            foreach ($scoreTypes as $scoreType) {
+                $total = GameScore::query()
+                    ->where('event_attendee_id', $attendee->id)
+                    ->where('event_score_type_id', $scoreType->id)
+                    ->sum('value');
+
+                EventStandingScore::factory()->for($standing, 'standing')->create([
+                    'event_score_type_id' => $scoreType->id,
+                    'value' => $total,
+                ]);
+            }
+        }
+    }
+
+    private function createFullStandings(Event $event, $attendees, array $scoreTypes): void
+    {
+        $this->createPartialStandings($event, $attendees, $scoreTypes);
+    }
+}

--- a/routes/api/events.php
+++ b/routes/api/events.php
@@ -1,7 +1,9 @@
 <?php
 
 use App\Http\Controllers\Events\ListEventsController;
+use App\Http\Controllers\Events\ListEventUpdatesController;
 use App\Http\Controllers\Events\ShowEventController;
 
 Route::get('events', ListEventsController::class)->name('events.index');
 Route::get('events/{event:slug}', ShowEventController::class)->name('events.show');
+Route::get('events/{event:slug}/updates', ListEventUpdatesController::class)->name('events.updates.index');

--- a/routes/api/events.php
+++ b/routes/api/events.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Events\ListEventAttendeesController;
 use App\Http\Controllers\Events\ListEventsController;
 use App\Http\Controllers\Events\ListEventUpdatesController;
 use App\Http\Controllers\Events\ShowEventController;
@@ -7,3 +8,4 @@ use App\Http\Controllers\Events\ShowEventController;
 Route::get('events', ListEventsController::class)->name('events.index');
 Route::get('events/{event:slug}', ShowEventController::class)->name('events.show');
 Route::get('events/{event:slug}/updates', ListEventUpdatesController::class)->name('events.updates.index');
+Route::get('events/{event:slug}/attendees', ListEventAttendeesController::class)->name('events.attendees.index');

--- a/routes/api/events.php
+++ b/routes/api/events.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Events\ListEventAttendeesController;
 use App\Http\Controllers\Events\ListEventRoundsController;
 use App\Http\Controllers\Events\ListEventsController;
+use App\Http\Controllers\Events\ListEventStandingsController;
 use App\Http\Controllers\Events\ListEventUpdatesController;
 use App\Http\Controllers\Events\ShowEventAttendeeController;
 use App\Http\Controllers\Events\ShowEventController;
@@ -19,3 +20,4 @@ Route::get('events/{event:slug}/rounds', ListEventRoundsController::class)->name
 Route::scopeBindings()->get('events/{event:slug}/rounds/{round}', ShowEventRoundController::class)
     ->name('events.rounds.show');
 Route::get('events/{event:slug}/games/{game}', ShowEventGameController::class)->name('events.games.show');
+Route::get('events/{event:slug}/standings', ListEventStandingsController::class)->name('events.standings.index');

--- a/routes/api/events.php
+++ b/routes/api/events.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Events\ListEventAttendeesController;
+use App\Http\Controllers\Events\ListEventGalleryController;
 use App\Http\Controllers\Events\ListEventRoundsController;
 use App\Http\Controllers\Events\ListEventsController;
 use App\Http\Controllers\Events\ListEventStandingsController;
@@ -21,3 +22,4 @@ Route::scopeBindings()->get('events/{event:slug}/rounds/{round}', ShowEventRound
     ->name('events.rounds.show');
 Route::get('events/{event:slug}/games/{game}', ShowEventGameController::class)->name('events.games.show');
 Route::get('events/{event:slug}/standings', ListEventStandingsController::class)->name('events.standings.index');
+Route::get('events/{event:slug}/gallery', ListEventGalleryController::class)->name('events.gallery.index');

--- a/routes/api/events.php
+++ b/routes/api/events.php
@@ -1,10 +1,13 @@
 <?php
 
 use App\Http\Controllers\Events\ListEventAttendeesController;
+use App\Http\Controllers\Events\ListEventRoundsController;
 use App\Http\Controllers\Events\ListEventsController;
 use App\Http\Controllers\Events\ListEventUpdatesController;
 use App\Http\Controllers\Events\ShowEventAttendeeController;
 use App\Http\Controllers\Events\ShowEventController;
+use App\Http\Controllers\Events\ShowEventGameController;
+use App\Http\Controllers\Events\ShowEventRoundController;
 
 Route::get('events', ListEventsController::class)->name('events.index');
 Route::get('events/{event:slug}', ShowEventController::class)->name('events.show');
@@ -12,3 +15,7 @@ Route::get('events/{event:slug}/updates', ListEventUpdatesController::class)->na
 Route::get('events/{event:slug}/attendees', ListEventAttendeesController::class)->name('events.attendees.index');
 Route::scopeBindings()->get('events/{event:slug}/attendees/{attendee}', ShowEventAttendeeController::class)
     ->name('events.attendees.show');
+Route::get('events/{event:slug}/rounds', ListEventRoundsController::class)->name('events.rounds.index');
+Route::scopeBindings()->get('events/{event:slug}/rounds/{round}', ShowEventRoundController::class)
+    ->name('events.rounds.show');
+Route::get('events/{event:slug}/games/{game}', ShowEventGameController::class)->name('events.games.show');

--- a/routes/api/events.php
+++ b/routes/api/events.php
@@ -1,0 +1,7 @@
+<?php
+
+use App\Http\Controllers\Events\ListEventsController;
+use App\Http\Controllers\Events\ShowEventController;
+
+Route::get('events', ListEventsController::class)->name('events.index');
+Route::get('events/{event:slug}', ShowEventController::class)->name('events.show');

--- a/routes/api/events.php
+++ b/routes/api/events.php
@@ -3,9 +3,12 @@
 use App\Http\Controllers\Events\ListEventAttendeesController;
 use App\Http\Controllers\Events\ListEventsController;
 use App\Http\Controllers\Events\ListEventUpdatesController;
+use App\Http\Controllers\Events\ShowEventAttendeeController;
 use App\Http\Controllers\Events\ShowEventController;
 
 Route::get('events', ListEventsController::class)->name('events.index');
 Route::get('events/{event:slug}', ShowEventController::class)->name('events.show');
 Route::get('events/{event:slug}/updates', ListEventUpdatesController::class)->name('events.updates.index');
 Route::get('events/{event:slug}/attendees', ListEventAttendeesController::class)->name('events.attendees.index');
+Route::scopeBindings()->get('events/{event:slug}/attendees/{attendee}', ShowEventAttendeeController::class)
+    ->name('events.attendees.show');

--- a/tests/Feature/Events/ListEventAttendeesTest.php
+++ b/tests/Feature/Events/ListEventAttendeesTest.php
@@ -1,0 +1,153 @@
+<?php
+
+use App\Models\Club;
+use App\Models\Event;
+use App\Models\EventAttendee;
+use App\Models\Faction;
+use App\Models\User;
+
+test('it returns paginated attendees with user, faction and clubs', function () {
+    $event = Event::factory()->published()->create();
+    $faction = Faction::factory()->create(['name' => 'Space Marines']);
+    $club = Club::factory()->create(['name' => 'London Warlords']);
+
+    $user = User::factory()->create(['name' => 'Alice Example']);
+    $user->clubs()->attach($club);
+
+    EventAttendee::factory()->for($event)->for($user)->for($faction)->create();
+
+    $this->getJson(route('events.attendees.index', ['event' => $event->slug]))
+        ->assertSuccessful()
+        ->assertJsonStructure(['data', 'links', 'meta'])
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.user.name', 'Alice Example')
+        ->assertJsonPath('data.0.faction.name', 'Space Marines')
+        ->assertJsonPath('data.0.clubs.0.name', 'London Warlords')
+        ->assertJsonPath('data.0.clubs.0.id', $club->id);
+});
+
+test('it returns 404 for non-publicly-visible events', function (string $state) {
+    $event = Event::factory()->{$state}()->create();
+
+    $this->getJson(route('events.attendees.index', ['event' => $event->slug]))
+        ->assertNotFound();
+})->with(['draft', 'cancelled']);
+
+test('it returns 404 for a nonexistent event slug', function () {
+    $this->getJson(route('events.attendees.index', ['event' => 'does-not-exist']))
+        ->assertNotFound();
+});
+
+test('it orders attendees alphabetically by user name', function () {
+    $event = Event::factory()->published()->create();
+
+    foreach (['Charlie', 'Alice', 'Bob'] as $name) {
+        EventAttendee::factory()
+            ->for($event)
+            ->for(User::factory()->create(['name' => $name]))
+            ->create();
+    }
+
+    $response = $this->getJson(route('events.attendees.index', ['event' => $event->slug]))
+        ->assertSuccessful();
+
+    expect(collect($response->json('data'))->pluck('user.name')->all())
+        ->toEqual(['Alice', 'Bob', 'Charlie']);
+});
+
+test('it does not leak attendees from other events', function () {
+    $event = Event::factory()->published()->create();
+    $otherEvent = Event::factory()->published()->create();
+
+    EventAttendee::factory()->for($event)->create();
+    EventAttendee::factory()->for($otherEvent)->count(3)->create();
+
+    $this->getJson(route('events.attendees.index', ['event' => $event->slug]))
+        ->assertSuccessful()
+        ->assertJsonCount(1, 'data');
+});
+
+test('it is a public endpoint requiring no auth', function () {
+    $event = Event::factory()->published()->create();
+
+    $this->getJson(route('events.attendees.index', ['event' => $event->slug]))
+        ->assertSuccessful();
+});
+
+test('it searches by faction name', function () {
+    $event = Event::factory()->published()->create();
+
+    $match = Faction::factory()->create(['name' => 'Necrons']);
+    $miss = Faction::factory()->create(['name' => 'Tyranids']);
+
+    EventAttendee::factory()->for($event)->for($match)->create();
+    EventAttendee::factory()->for($event)->for($miss)->create();
+
+    $this->getJson(route('events.attendees.index', ['event' => $event->slug, 'search' => 'necr']))
+        ->assertSuccessful()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.faction.name', 'Necrons');
+});
+
+test('it searches by club name', function () {
+    $event = Event::factory()->published()->create();
+
+    $matchClub = Club::factory()->create(['name' => 'London Warlords']);
+    $missClub = Club::factory()->create(['name' => 'Manchester Marauders']);
+
+    $matchUser = User::factory()->create();
+    $matchUser->clubs()->attach($matchClub);
+    $missUser = User::factory()->create();
+    $missUser->clubs()->attach($missClub);
+
+    EventAttendee::factory()->for($event)->for($matchUser)->create();
+    EventAttendee::factory()->for($event)->for($missUser)->create();
+
+    $this->getJson(route('events.attendees.index', ['event' => $event->slug, 'search' => 'warlords']))
+        ->assertSuccessful()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.clubs.0.name', 'London Warlords');
+});
+
+test('it returns an empty result when search matches nothing', function () {
+    $event = Event::factory()->published()->create();
+    EventAttendee::factory()->for($event)->count(3)->create();
+
+    $this->getJson(route('events.attendees.index', ['event' => $event->slug, 'search' => 'zzznomatchzzz']))
+        ->assertSuccessful()
+        ->assertJsonCount(0, 'data');
+});
+
+test('search does not leak attendees from other events', function () {
+    $event = Event::factory()->published()->create();
+    $otherEvent = Event::factory()->published()->create();
+
+    $targetUser = User::factory()->create(['name' => 'Target Person']);
+    EventAttendee::factory()->for($otherEvent)->for($targetUser)->create();
+
+    $this->getJson(route('events.attendees.index', ['event' => $event->slug, 'search' => 'target']))
+        ->assertSuccessful()
+        ->assertJsonCount(0, 'data');
+});
+
+test('it rejects a non-string search param', function () {
+    $event = Event::factory()->published()->create();
+
+    $this->getJson(route('events.attendees.index', ['event' => $event->slug, 'search' => ['not', 'a', 'string']]))
+        ->assertUnprocessable();
+});
+
+test('it searches by user name case-insensitively', function () {
+    $event = Event::factory()->published()->create();
+
+    $match = User::factory()->create(['name' => 'Alice Anderson']);
+    $miss = User::factory()->create(['name' => 'Bob Brown']);
+
+    EventAttendee::factory()->for($event)->for($match)->create();
+    EventAttendee::factory()->for($event)->for($miss)->create();
+
+    $this->getJson(route('events.attendees.index', ['event' => $event->slug, 'search' => 'ALICE']))
+        ->assertSuccessful()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.user.name', 'Alice Anderson');
+});

--- a/tests/Feature/Events/ListEventGalleryTest.php
+++ b/tests/Feature/Events/ListEventGalleryTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use App\Models\Event;
+use App\Models\Photo;
+use App\Models\Reaction;
+use App\Models\User;
+
+test('it returns paginated photos for an event, latest first', function () {
+    $event = Event::factory()->published()->create();
+    $user = User::factory()->create();
+
+    $older = Photo::factory()->for($user)->create([
+        'event_id' => $event->id,
+        'created_at' => now()->subDay(),
+    ]);
+    $newer = Photo::factory()->for($user)->create([
+        'event_id' => $event->id,
+        'created_at' => now(),
+    ]);
+
+    $this->getJson(route('events.gallery.index', ['event' => $event->slug]))
+        ->assertSuccessful()
+        ->assertJsonStructure(['data', 'links', 'meta'])
+        ->assertJsonCount(2, 'data')
+        ->assertJsonPath('data.0.id', $newer->id)
+        ->assertJsonPath('data.1.id', $older->id);
+});
+
+test('it returns 404 for non-publicly-visible events', function (string $state) {
+    $event = Event::factory()->{$state}()->create();
+
+    $this->getJson(route('events.gallery.index', ['event' => $event->slug]))
+        ->assertNotFound();
+})->with(['draft', 'cancelled']);
+
+test('it includes reaction counts', function () {
+    $event = Event::factory()->published()->create();
+    $user = User::factory()->create();
+    $photo = Photo::factory()->for($user)->create(['event_id' => $event->id]);
+
+    Reaction::factory()->count(3)->for($photo, 'reactable')->create();
+
+    $this->getJson(route('events.gallery.index', ['event' => $event->slug]))
+        ->assertSuccessful()
+        ->assertJsonPath('data.0.reactions_count', 3);
+});
+
+test('it includes has_reacted when authenticated', function () {
+    $event = Event::factory()->published()->create();
+    $user = User::factory()->create();
+
+    $reactedPhoto = Photo::factory()->for($user)->create(['event_id' => $event->id]);
+    $unreactedPhoto = Photo::factory()->for($user)->create(['event_id' => $event->id]);
+
+    Reaction::factory()->for($reactedPhoto, 'reactable')->create(['user_id' => $user->id]);
+
+    $response = $this->actingAs($user)
+        ->getJson(route('events.gallery.index', ['event' => $event->slug]))
+        ->assertSuccessful();
+
+    $data = collect($response->json('data'));
+    $reacted = $data->firstWhere('id', $reactedPhoto->id);
+    $unreacted = $data->firstWhere('id', $unreactedPhoto->id);
+
+    expect($reacted['has_reacted'])->toBeTrue()
+        ->and($unreacted['has_reacted'])->toBeFalse();
+});
+
+test('it does not include has_reacted when unauthenticated', function () {
+    $event = Event::factory()->published()->create();
+    $user = User::factory()->create();
+    $photo = Photo::factory()->for($user)->create(['event_id' => $event->id]);
+
+    Reaction::factory()->for($photo, 'reactable')->create(['user_id' => $user->id]);
+
+    $response = $this->getJson(route('events.gallery.index', ['event' => $event->slug]))
+        ->assertSuccessful();
+
+    expect($response->json('data.0'))->not->toHaveKey('has_reacted');
+});
+
+test('it returns empty paginated response when event has no photos', function () {
+    $event = Event::factory()->published()->create();
+
+    $this->getJson(route('events.gallery.index', ['event' => $event->slug]))
+        ->assertSuccessful()
+        ->assertJsonStructure(['data', 'links', 'meta'])
+        ->assertJsonCount(0, 'data');
+});
+
+test('it does not leak photos from other events', function () {
+    $event = Event::factory()->published()->create();
+    $otherEvent = Event::factory()->published()->create();
+    $user = User::factory()->create();
+
+    Photo::factory()->for($user)->create(['event_id' => $event->id]);
+    Photo::factory()->for($user)->create(['event_id' => $otherEvent->id]);
+    Photo::factory()->for($user)->create();
+
+    $this->getJson(route('events.gallery.index', ['event' => $event->slug]))
+        ->assertSuccessful()
+        ->assertJsonCount(1, 'data');
+});

--- a/tests/Feature/Events/ListEventRoundsTest.php
+++ b/tests/Feature/Events/ListEventRoundsTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use App\Models\Event;
+use App\Models\Round;
+
+test('it returns rounds for a completed event', function () {
+    $event = Event::factory()->completed()->create();
+    Round::factory()->for($event)->create(['number' => 1]);
+
+    $this->getJson(route('events.rounds.index', ['event' => $event->slug]))
+        ->assertSuccessful()
+        ->assertJsonCount(1, 'data');
+});
+
+test('it returns 404 for events without rounds visibility', function (string $state) {
+    $event = Event::factory()->{$state}()->create();
+    Round::factory()->for($event)->create(['number' => 1]);
+
+    $this->getJson(route('events.rounds.index', ['event' => $event->slug]))
+        ->assertNotFound();
+})->with(['draft', 'published', 'cancelled']);
+
+test('it returns rounds ordered by number for an active event', function () {
+    $event = Event::factory()->active()->create();
+
+    Round::factory()->for($event)->create(['number' => 3]);
+    Round::factory()->for($event)->create(['number' => 1]);
+    Round::factory()->for($event)->create(['number' => 2]);
+
+    $response = $this->getJson(route('events.rounds.index', ['event' => $event->slug]))
+        ->assertSuccessful()
+        ->assertJsonCount(3, 'data');
+
+    expect(collect($response->json('data'))->pluck('number')->all())
+        ->toEqual([1, 2, 3]);
+});
+
+test('it does not leak rounds from other events', function () {
+    $event = Event::factory()->active()->create();
+    $otherEvent = Event::factory()->active()->create();
+
+    Round::factory()->for($event)->create(['number' => 1]);
+    Round::factory()->for($otherEvent)->count(3)->create();
+
+    $this->getJson(route('events.rounds.index', ['event' => $event->slug]))
+        ->assertSuccessful()
+        ->assertJsonCount(1, 'data');
+});
+
+test('it is a public endpoint requiring no auth', function () {
+    $event = Event::factory()->active()->create();
+
+    $this->getJson(route('events.rounds.index', ['event' => $event->slug]))
+        ->assertSuccessful();
+});
+
+test('it returns 404 for a nonexistent event slug', function () {
+    $this->getJson(route('events.rounds.index', ['event' => 'does-not-exist']))
+        ->assertNotFound();
+});

--- a/tests/Feature/Events/ListEventStandingsTest.php
+++ b/tests/Feature/Events/ListEventStandingsTest.php
@@ -1,0 +1,183 @@
+<?php
+
+use App\Models\Club;
+use App\Models\Event;
+use App\Models\EventAttendee;
+use App\Models\EventScoreType;
+use App\Models\EventStanding;
+use App\Models\EventStandingScore;
+use App\Models\Faction;
+use App\Models\User;
+
+test('it returns standings ordered by position', function () {
+    $event = Event::factory()->published()->standingsVisible()->create();
+
+    $attendee1 = EventAttendee::factory()->for($event)->for(User::factory()->create(['name' => 'First Place']))->create();
+    $attendee2 = EventAttendee::factory()->for($event)->for(User::factory()->create(['name' => 'Second Place']))->create();
+    $attendee3 = EventAttendee::factory()->for($event)->for(User::factory()->create(['name' => 'Third Place']))->create();
+
+    EventStanding::factory()->for($event)->for($attendee3, 'attendee')->create(['position' => 3]);
+    EventStanding::factory()->for($event)->for($attendee1, 'attendee')->create(['position' => 1]);
+    EventStanding::factory()->for($event)->for($attendee2, 'attendee')->create(['position' => 2]);
+
+    $response = $this->getJson(route('events.standings.index', ['event' => $event->slug]))
+        ->assertSuccessful()
+        ->assertJsonStructure(['data', 'links', 'meta'])
+        ->assertJsonCount(3, 'data');
+
+    expect(collect($response->json('data'))->pluck('position')->all())
+        ->toEqual([1, 2, 3]);
+
+    expect($response->json('data.0.attendee.name'))->toBe('First Place');
+});
+
+test('it returns 404 when standings_visible is false', function () {
+    $event = Event::factory()->published()->create(['standings_visible' => false]);
+
+    $this->getJson(route('events.standings.index', ['event' => $event->slug]))
+        ->assertNotFound();
+});
+
+test('it returns 404 for non-publicly-visible events', function (string $state) {
+    $event = Event::factory()->{$state}()->standingsVisible()->create();
+
+    $this->getJson(route('events.standings.index', ['event' => $event->slug]))
+        ->assertNotFound();
+})->with(['draft', 'cancelled']);
+
+test('it includes attendee info and score values with type metadata', function () {
+    $event = Event::factory()->published()->standingsVisible()->create();
+    $scoreType = EventScoreType::factory()->for($event)->create([
+        'name' => 'Battle Points',
+        'slug' => 'battle-points',
+        'sort_direction' => 'desc',
+    ]);
+
+    $user = User::factory()->create(['name' => 'Alice']);
+    $attendee = EventAttendee::factory()->for($event)->for($user)->create();
+    $standing = EventStanding::factory()->for($event)->for($attendee, 'attendee')->create(['position' => 1]);
+    EventStandingScore::factory()->for($standing, 'standing')->for($scoreType, 'scoreType')->create(['value' => 75.50]);
+
+    $response = $this->getJson(route('events.standings.index', ['event' => $event->slug]))
+        ->assertSuccessful();
+
+    $data = $response->json('data.0');
+    expect($data['position'])->toBe(1);
+    expect($data['attendee']['name'])->toBe('Alice');
+    expect($data['scores'][0]['value'])->toBe('75.50');
+    expect($data['scores'][0]['score_type']['name'])->toBe('Battle Points');
+    expect($data['scores'][0]['score_type']['slug'])->toBe('battle-points');
+    expect($data['scores'][0]['score_type']['sort_direction'])->toBe('desc');
+});
+
+test('it sorts by score type value descending when sort_direction is desc', function () {
+    $event = Event::factory()->published()->standingsVisible()->create();
+    $scoreType = EventScoreType::factory()->for($event)->create([
+        'slug' => 'battle-points',
+        'sort_direction' => 'desc',
+    ]);
+
+    $lowUser = User::factory()->create(['name' => 'Low Scorer']);
+    $highUser = User::factory()->create(['name' => 'High Scorer']);
+
+    $lowAttendee = EventAttendee::factory()->for($event)->for($lowUser)->create();
+    $highAttendee = EventAttendee::factory()->for($event)->for($highUser)->create();
+
+    $lowStanding = EventStanding::factory()->for($event)->for($lowAttendee, 'attendee')->create(['position' => 1]);
+    $highStanding = EventStanding::factory()->for($event)->for($highAttendee, 'attendee')->create(['position' => 2]);
+
+    EventStandingScore::factory()->for($lowStanding, 'standing')->for($scoreType, 'scoreType')->create(['value' => 10]);
+    EventStandingScore::factory()->for($highStanding, 'standing')->for($scoreType, 'scoreType')->create(['value' => 90]);
+
+    $response = $this->getJson(route('events.standings.index', ['event' => $event->slug, 'sort_by' => 'battle-points']))
+        ->assertSuccessful();
+
+    // sort_by overrides position order — High Scorer (90) comes first in desc
+    $names = collect($response->json('data'))->pluck('attendee.name')->all();
+    expect($names)->toEqual(['High Scorer', 'Low Scorer']);
+});
+
+test('it sorts by score type value ascending when sort_direction is asc', function () {
+    $event = Event::factory()->published()->standingsVisible()->create();
+    $scoreType = EventScoreType::factory()->for($event)->create([
+        'slug' => 'penalties',
+        'sort_direction' => 'asc',
+    ]);
+
+    $lowUser = User::factory()->create(['name' => 'Few Penalties']);
+    $highUser = User::factory()->create(['name' => 'Many Penalties']);
+
+    $lowAttendee = EventAttendee::factory()->for($event)->for($lowUser)->create();
+    $highAttendee = EventAttendee::factory()->for($event)->for($highUser)->create();
+
+    $lowStanding = EventStanding::factory()->for($event)->for($lowAttendee, 'attendee')->create(['position' => 2]);
+    $highStanding = EventStanding::factory()->for($event)->for($highAttendee, 'attendee')->create(['position' => 1]);
+
+    EventStandingScore::factory()->for($lowStanding, 'standing')->for($scoreType, 'scoreType')->create(['value' => 5]);
+    EventStandingScore::factory()->for($highStanding, 'standing')->for($scoreType, 'scoreType')->create(['value' => 50]);
+
+    $response = $this->getJson(route('events.standings.index', ['event' => $event->slug, 'sort_by' => 'penalties']))
+        ->assertSuccessful();
+
+    // sort_by overrides position order — Few Penalties (5) comes first in asc
+    $names = collect($response->json('data'))->pluck('attendee.name')->all();
+    expect($names)->toEqual(['Few Penalties', 'Many Penalties']);
+});
+
+test('it returns 422 for invalid sort_by value', function () {
+    $event = Event::factory()->published()->standingsVisible()->create();
+    EventScoreType::factory()->for($event)->create(['slug' => 'battle-points']);
+
+    $this->getJson(route('events.standings.index', ['event' => $event->slug, 'sort_by' => 'nonexistent-type']))
+        ->assertStatus(422);
+});
+
+test('it searches by attendee user name', function () {
+    $event = Event::factory()->published()->standingsVisible()->create();
+
+    $match = EventAttendee::factory()->for($event)->for(User::factory()->create(['name' => 'Alice Anderson']))->create();
+    $miss = EventAttendee::factory()->for($event)->for(User::factory()->create(['name' => 'Bob Brown']))->create();
+
+    EventStanding::factory()->for($event)->for($match, 'attendee')->create(['position' => 1]);
+    EventStanding::factory()->for($event)->for($miss, 'attendee')->create(['position' => 2]);
+
+    $this->getJson(route('events.standings.index', ['event' => $event->slug, 'search' => 'alice']))
+        ->assertSuccessful()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.attendee.name', 'Alice Anderson');
+});
+
+test('it searches by faction name', function () {
+    $event = Event::factory()->published()->standingsVisible()->create();
+
+    $matchFaction = Faction::factory()->create(['name' => 'Space Marines']);
+    $missFaction = Faction::factory()->create(['name' => 'Tyranids']);
+
+    $match = EventAttendee::factory()->for($event)->for($matchFaction)->create();
+    $miss = EventAttendee::factory()->for($event)->for($missFaction)->create();
+
+    EventStanding::factory()->for($event)->for($match, 'attendee')->create(['position' => 1]);
+    EventStanding::factory()->for($event)->for($miss, 'attendee')->create(['position' => 2]);
+
+    $this->getJson(route('events.standings.index', ['event' => $event->slug, 'search' => 'marines']))
+        ->assertSuccessful()
+        ->assertJsonCount(1, 'data');
+});
+
+test('it searches by club name', function () {
+    $event = Event::factory()->published()->standingsVisible()->create();
+
+    $club = Club::factory()->create(['name' => 'London Warlords']);
+    $user = User::factory()->create();
+    $user->clubs()->attach($club);
+
+    $match = EventAttendee::factory()->for($event)->for($user)->create();
+    $miss = EventAttendee::factory()->for($event)->create();
+
+    EventStanding::factory()->for($event)->for($match, 'attendee')->create(['position' => 1]);
+    EventStanding::factory()->for($event)->for($miss, 'attendee')->create(['position' => 2]);
+
+    $this->getJson(route('events.standings.index', ['event' => $event->slug, 'search' => 'warlords']))
+        ->assertSuccessful()
+        ->assertJsonCount(1, 'data');
+});

--- a/tests/Feature/Events/ListEventUpdatesTest.php
+++ b/tests/Feature/Events/ListEventUpdatesTest.php
@@ -1,0 +1,134 @@
+<?php
+
+use App\Models\Event;
+use App\Models\EventUpdate;
+use App\Models\EventUpdateAttachment;
+use App\Models\User;
+
+test('it returns updates for a publicly visible event', function () {
+    $event = Event::factory()->published()->create();
+    EventUpdate::factory()->count(3)->for($event)->create();
+
+    $this->getJson(route('events.updates.index', $event))
+        ->assertSuccessful()
+        ->assertJsonCount(3, 'data');
+});
+
+test('it is a public endpoint requiring no auth', function () {
+    $event = Event::factory()->published()->create();
+
+    $this->getJson(route('events.updates.index', $event))->assertSuccessful();
+});
+
+test('it paginates results', function () {
+    $event = Event::factory()->published()->create();
+    EventUpdate::factory()->count(20)->for($event)->create();
+
+    $this->getJson(route('events.updates.index', $event))
+        ->assertSuccessful()
+        ->assertJsonStructure(['data', 'links', 'meta']);
+});
+
+test('it orders pinned updates before others', function () {
+    $event = Event::factory()->published()->create();
+
+    $older = EventUpdate::factory()->for($event)->create([
+        'published_at' => now()->subDays(5),
+    ]);
+    $newer = EventUpdate::factory()->for($event)->create([
+        'published_at' => now()->subDay(),
+    ]);
+    $pinned = EventUpdate::factory()->pinned()->for($event)->create([
+        'published_at' => now()->subDays(10),
+    ]);
+
+    $response = $this->getJson(route('events.updates.index', $event))
+        ->assertSuccessful();
+
+    expect($response->json('data.0.id'))->toBe($pinned->id)
+        ->and($response->json('data.1.id'))->toBe($newer->id)
+        ->and($response->json('data.2.id'))->toBe($older->id);
+});
+
+test('it orders non-pinned updates by published_at descending', function () {
+    $event = Event::factory()->published()->create();
+
+    $first = EventUpdate::factory()->for($event)->create([
+        'published_at' => now()->subDays(3),
+    ]);
+    $latest = EventUpdate::factory()->for($event)->create([
+        'published_at' => now(),
+    ]);
+    $middle = EventUpdate::factory()->for($event)->create([
+        'published_at' => now()->subDay(),
+    ]);
+
+    $response = $this->getJson(route('events.updates.index', $event))
+        ->assertSuccessful();
+
+    expect($response->json('data.0.id'))->toBe($latest->id)
+        ->and($response->json('data.1.id'))->toBe($middle->id)
+        ->and($response->json('data.2.id'))->toBe($first->id);
+});
+
+test('it includes the author id and name', function () {
+    $event = Event::factory()->published()->create();
+    $author = User::factory()->create(['name' => 'Jane Organiser']);
+    EventUpdate::factory()->for($event)->for($author, 'author')->create();
+
+    $this->getJson(route('events.updates.index', $event))
+        ->assertSuccessful()
+        ->assertJsonPath('data.0.author.id', $author->id)
+        ->assertJsonPath('data.0.author.name', 'Jane Organiser');
+});
+
+test('it includes attachments ordered by display_order', function () {
+    $event = Event::factory()->published()->create();
+    $update = EventUpdate::factory()->for($event)->create();
+
+    EventUpdateAttachment::factory()->for($update)->create([
+        'name' => 'Second',
+        'display_order' => 2,
+    ]);
+    EventUpdateAttachment::factory()->for($update)->create([
+        'name' => 'First',
+        'display_order' => 1,
+    ]);
+
+    $response = $this->getJson(route('events.updates.index', $event))
+        ->assertSuccessful()
+        ->assertJsonCount(2, 'data.0.attachments')
+        ->assertJsonPath('data.0.attachments.0.name', 'First')
+        ->assertJsonPath('data.0.attachments.1.name', 'Second');
+
+    $attachment = $response->json('data.0.attachments.0');
+    expect($attachment)->toHaveKeys(['id', 'name', 'url', 'display_order']);
+});
+
+test('it scopes updates to the requested event', function () {
+    $event = Event::factory()->published()->create();
+    $otherEvent = Event::factory()->published()->create();
+
+    EventUpdate::factory()->count(2)->for($event)->create();
+    EventUpdate::factory()->count(3)->for($otherEvent)->create();
+
+    $this->getJson(route('events.updates.index', $event))
+        ->assertSuccessful()
+        ->assertJsonCount(2, 'data');
+});
+
+test('it returns 404 for a draft event', function () {
+    $event = Event::factory()->draft()->create();
+
+    $this->getJson(route('events.updates.index', $event))->assertNotFound();
+});
+
+test('it returns 404 for a cancelled event', function () {
+    $event = Event::factory()->cancelled()->create();
+
+    $this->getJson(route('events.updates.index', $event))->assertNotFound();
+});
+
+test('it returns 404 for a non-existent slug', function () {
+    $this->getJson(route('events.updates.index', 'does-not-exist'))->assertNotFound();
+});

--- a/tests/Feature/Events/ListEventsTest.php
+++ b/tests/Feature/Events/ListEventsTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use App\Models\Event;
+use App\Models\GameSystem;
+
+test('it returns only publicly visible events', function () {
+    Event::factory()->published()->create();
+    Event::factory()->active()->create();
+    Event::factory()->completed()->create();
+    Event::factory()->draft()->create();
+    Event::factory()->cancelled()->create();
+
+    $this->getJson(route('events.index'))
+        ->assertSuccessful()
+        ->assertJsonCount(3, 'data');
+});
+
+test('it is a public endpoint requiring no auth', function () {
+    Event::factory()->published()->create();
+
+    $this->getJson(route('events.index'))->assertSuccessful();
+});
+
+test('it paginates results', function () {
+    Event::factory()->count(20)->published()->create();
+
+    $this->getJson(route('events.index'))
+        ->assertSuccessful()
+        ->assertJsonStructure(['data', 'links', 'meta']);
+});
+
+test('it can be filtered by status', function () {
+    Event::factory()->published()->create();
+    Event::factory()->active()->create();
+    Event::factory()->completed()->create();
+
+    $this->getJson(route('events.index', ['status' => 'active']))
+        ->assertSuccessful()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.status', 'active');
+});
+
+test('it rejects a status filter for a non-publicly-visible status', function () {
+    Event::factory()->draft()->create();
+
+    $this->getJson(route('events.index', ['status' => 'draft']))
+        ->assertUnprocessable();
+});
+
+test('it can be filtered by game_system slug', function () {
+    $wh40k = GameSystem::factory()->create(['slug' => 'warhammer-40k']);
+    $aos = GameSystem::factory()->create(['slug' => 'age-of-sigmar']);
+
+    Event::factory()->published()->for($wh40k, 'gameSystem')->create();
+    Event::factory()->published()->for($aos, 'gameSystem')->create();
+
+    $this->getJson(route('events.index', ['game_system' => 'warhammer-40k']))
+        ->assertSuccessful()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.game_system.slug', 'warhammer-40k');
+});
+
+test('it can be searched by name', function () {
+    Event::factory()->published()->create(['name' => 'London Grand Tournament']);
+    Event::factory()->published()->create(['name' => 'Birmingham Open']);
+
+    $this->getJson(route('events.index', ['search' => 'london']))
+        ->assertSuccessful()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.name', 'London Grand Tournament');
+});
+
+test('it rejects unknown status values', function () {
+    $this->getJson(route('events.index', ['status' => 'bogus']))
+        ->assertUnprocessable();
+});

--- a/tests/Feature/Events/ShowEventAttendeeTest.php
+++ b/tests/Feature/Events/ShowEventAttendeeTest.php
@@ -7,6 +7,8 @@ use App\Models\EventAttendee;
 use App\Models\EventCustomField;
 use App\Models\EventCustomFieldResponse;
 use App\Models\Faction;
+use App\Models\Game;
+use App\Models\Round;
 use App\Models\User;
 
 test('it returns attendee detail with user, faction, clubs, army_list, checked_in_at and empty games', function () {
@@ -180,6 +182,31 @@ test('number custom field values are returned as integers', function () {
     $this->getJson(route('events.attendees.show', ['event' => $event->slug, 'attendee' => $attendee->id]))
         ->assertSuccessful()
         ->assertJsonPath('data.custom_field_responses.0.value', 2000);
+});
+
+test('it returns games list with round number, opponent, scores and is_bye', function () {
+    $event = Event::factory()->active()->create();
+    $user1 = User::factory()->create(['name' => 'Alice']);
+    $user2 = User::factory()->create(['name' => 'Bob']);
+
+    $attendee1 = EventAttendee::factory()->for($event)->for($user1)->create();
+    $attendee2 = EventAttendee::factory()->for($event)->for($user2)->create();
+
+    $round = Round::factory()->for($event)->create(['number' => 1]);
+    $game = Game::factory()->for($round)->create(['table_number' => 3]);
+    $game->attendees()->attach($attendee1, ['score' => 85]);
+    $game->attendees()->attach($attendee2, ['score' => 70]);
+
+    $response = $this->getJson(route('events.attendees.show', ['event' => $event->slug, 'attendee' => $attendee1->id]))
+        ->assertSuccessful();
+
+    expect($response->json('data.games'))->toHaveCount(1)
+        ->and($response->json('data.games.0.round_number'))->toBe(1)
+        ->and($response->json('data.games.0.table_number'))->toBe(3)
+        ->and($response->json('data.games.0.is_bye'))->toBeFalse()
+        ->and($response->json('data.games.0.score'))->toBe(85)
+        ->and($response->json('data.games.0.opponents'))->toHaveCount(1)
+        ->and($response->json('data.games.0.opponents.0.name'))->toBe('Bob');
 });
 
 test('it does not leak custom field responses from other attendees', function () {

--- a/tests/Feature/Events/ShowEventAttendeeTest.php
+++ b/tests/Feature/Events/ShowEventAttendeeTest.php
@@ -1,8 +1,11 @@
 <?php
 
+use App\Enums\CustomFieldType;
 use App\Models\Club;
 use App\Models\Event;
 use App\Models\EventAttendee;
+use App\Models\EventCustomField;
+use App\Models\EventCustomFieldResponse;
 use App\Models\Faction;
 use App\Models\User;
 
@@ -78,4 +81,120 @@ test('it is a public endpoint requiring no auth', function () {
 
     $this->getJson(route('events.attendees.show', ['event' => $event->slug, 'attendee' => $attendee->id]))
         ->assertSuccessful();
+});
+
+test('it returns custom field responses for a text field', function () {
+    $event = Event::factory()->published()->create();
+    $attendee = EventAttendee::factory()->for($event)->create();
+
+    $field = EventCustomField::factory()->for($event)->create([
+        'name' => 'Preferred Table',
+        'type' => CustomFieldType::Text,
+        'display_order' => 1,
+    ]);
+
+    EventCustomFieldResponse::factory()
+        ->for($attendee, 'attendee')
+        ->for($field, 'field')
+        ->create(['value' => 'Near the window']);
+
+    $this->getJson(route('events.attendees.show', ['event' => $event->slug, 'attendee' => $attendee->id]))
+        ->assertSuccessful()
+        ->assertJsonPath('data.custom_field_responses.0.id', $field->id)
+        ->assertJsonPath('data.custom_field_responses.0.name', 'Preferred Table')
+        ->assertJsonPath('data.custom_field_responses.0.type', 'text')
+        ->assertJsonPath('data.custom_field_responses.0.value', 'Near the window');
+});
+
+test('custom field responses are ordered by display_order', function () {
+    $event = Event::factory()->published()->create();
+    $attendee = EventAttendee::factory()->for($event)->create();
+
+    $second = EventCustomField::factory()->for($event)->create([
+        'name' => 'Second',
+        'display_order' => 2,
+    ]);
+    $first = EventCustomField::factory()->for($event)->create([
+        'name' => 'First',
+        'display_order' => 1,
+    ]);
+
+    EventCustomFieldResponse::factory()->for($attendee, 'attendee')->for($second, 'field')->create(['value' => 'b']);
+    EventCustomFieldResponse::factory()->for($attendee, 'attendee')->for($first, 'field')->create(['value' => 'a']);
+
+    $response = $this->getJson(route('events.attendees.show', ['event' => $event->slug, 'attendee' => $attendee->id]))
+        ->assertSuccessful();
+
+    expect(collect($response->json('data.custom_field_responses'))->pluck('name')->all())
+        ->toEqual(['First', 'Second']);
+});
+
+test('attendee with no custom field responses returns an empty array', function () {
+    $event = Event::factory()->published()->create();
+    $attendee = EventAttendee::factory()->for($event)->create();
+
+    EventCustomField::factory()->for($event)->create();
+
+    $response = $this->getJson(route('events.attendees.show', ['event' => $event->slug, 'attendee' => $attendee->id]))
+        ->assertSuccessful()
+        ->assertJsonStructure(['data' => ['custom_field_responses']]);
+
+    expect($response->json('data.custom_field_responses'))->toBe([]);
+});
+
+test('checkbox custom field values are returned as booleans', function () {
+    $event = Event::factory()->published()->create();
+    $attendee = EventAttendee::factory()->for($event)->create();
+
+    $yesField = EventCustomField::factory()->for($event)->create([
+        'name' => 'Attending Dinner',
+        'type' => CustomFieldType::Checkbox,
+        'display_order' => 1,
+    ]);
+    $noField = EventCustomField::factory()->for($event)->create([
+        'name' => 'Needs Parking',
+        'type' => CustomFieldType::Checkbox,
+        'display_order' => 2,
+    ]);
+
+    EventCustomFieldResponse::factory()->for($attendee, 'attendee')->for($yesField, 'field')->create(['value' => '1']);
+    EventCustomFieldResponse::factory()->for($attendee, 'attendee')->for($noField, 'field')->create(['value' => '0']);
+
+    $this->getJson(route('events.attendees.show', ['event' => $event->slug, 'attendee' => $attendee->id]))
+        ->assertSuccessful()
+        ->assertJsonPath('data.custom_field_responses.0.value', true)
+        ->assertJsonPath('data.custom_field_responses.1.value', false);
+});
+
+test('number custom field values are returned as integers', function () {
+    $event = Event::factory()->published()->create();
+    $attendee = EventAttendee::factory()->for($event)->create();
+
+    $field = EventCustomField::factory()->for($event)->create([
+        'name' => 'Points Level',
+        'type' => CustomFieldType::Number,
+    ]);
+
+    EventCustomFieldResponse::factory()->for($attendee, 'attendee')->for($field, 'field')->create(['value' => '2000']);
+
+    $this->getJson(route('events.attendees.show', ['event' => $event->slug, 'attendee' => $attendee->id]))
+        ->assertSuccessful()
+        ->assertJsonPath('data.custom_field_responses.0.value', 2000);
+});
+
+test('it does not leak custom field responses from other attendees', function () {
+    $event = Event::factory()->published()->create();
+    $attendee = EventAttendee::factory()->for($event)->create();
+    $otherAttendee = EventAttendee::factory()->for($event)->create();
+
+    $field = EventCustomField::factory()->for($event)->create(['name' => 'Army Points']);
+
+    EventCustomFieldResponse::factory()
+        ->for($otherAttendee, 'attendee')
+        ->for($field, 'field')
+        ->create(['value' => 'should not appear']);
+
+    $this->getJson(route('events.attendees.show', ['event' => $event->slug, 'attendee' => $attendee->id]))
+        ->assertSuccessful()
+        ->assertJsonPath('data.custom_field_responses', []);
 });

--- a/tests/Feature/Events/ShowEventAttendeeTest.php
+++ b/tests/Feature/Events/ShowEventAttendeeTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use App\Models\Club;
+use App\Models\Event;
+use App\Models\EventAttendee;
+use App\Models\Faction;
+use App\Models\User;
+
+test('it returns attendee detail with user, faction, clubs, army_list, checked_in_at and empty games', function () {
+    $event = Event::factory()->published()->create();
+    $faction = Faction::factory()->create(['name' => 'Space Marines']);
+    $club = Club::factory()->create(['name' => 'London Warlords']);
+
+    $user = User::factory()->create(['name' => 'Alice Example']);
+    $user->clubs()->attach($club);
+
+    $attendee = EventAttendee::factory()
+        ->for($event)
+        ->for($user)
+        ->for($faction)
+        ->create([
+            'army_list' => '1500pts Ultramarines list...',
+            'checked_in_at' => '2026-04-12 09:30:00',
+        ]);
+
+    $this->getJson(route('events.attendees.show', ['event' => $event->slug, 'attendee' => $attendee->id]))
+        ->assertSuccessful()
+        ->assertJsonPath('data.id', $attendee->id)
+        ->assertJsonPath('data.user.id', $user->id)
+        ->assertJsonPath('data.user.name', 'Alice Example')
+        ->assertJsonPath('data.faction.name', 'Space Marines')
+        ->assertJsonPath('data.clubs.0.id', $club->id)
+        ->assertJsonPath('data.clubs.0.name', 'London Warlords')
+        ->assertJsonPath('data.army_list', '1500pts Ultramarines list...')
+        ->assertJsonPath('data.checked_in_at', '2026-04-12T09:30:00Z')
+        ->assertJsonPath('data.games', []);
+});
+
+test('games is always an explicit empty array until games are implemented', function () {
+    $event = Event::factory()->published()->create();
+    $attendee = EventAttendee::factory()->for($event)->create();
+
+    $response = $this->getJson(route('events.attendees.show', ['event' => $event->slug, 'attendee' => $attendee->id]))
+        ->assertSuccessful()
+        ->assertJsonStructure(['data' => ['games']]);
+
+    expect($response->json('data.games'))->toBe([]);
+});
+
+test('it returns 404 when the attendee belongs to a different event', function () {
+    $event = Event::factory()->published()->create();
+    $otherEvent = Event::factory()->published()->create();
+
+    $attendee = EventAttendee::factory()->for($otherEvent)->create();
+
+    $this->getJson(route('events.attendees.show', ['event' => $event->slug, 'attendee' => $attendee->id]))
+        ->assertNotFound();
+});
+
+test('it returns 404 for non-publicly-visible events', function (string $state) {
+    $event = Event::factory()->{$state}()->create();
+    $attendee = EventAttendee::factory()->for($event)->create();
+
+    $this->getJson(route('events.attendees.show', ['event' => $event->slug, 'attendee' => $attendee->id]))
+        ->assertNotFound();
+})->with(['draft', 'cancelled']);
+
+test('it returns 404 for a nonexistent attendee id', function () {
+    $event = Event::factory()->published()->create();
+
+    $this->getJson(route('events.attendees.show', ['event' => $event->slug, 'attendee' => 999999]))
+        ->assertNotFound();
+});
+
+test('it is a public endpoint requiring no auth', function () {
+    $event = Event::factory()->published()->create();
+    $attendee = EventAttendee::factory()->for($event)->create();
+
+    $this->getJson(route('events.attendees.show', ['event' => $event->slug, 'attendee' => $attendee->id]))
+        ->assertSuccessful();
+});

--- a/tests/Feature/Events/ShowEventGameTest.php
+++ b/tests/Feature/Events/ShowEventGameTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use App\Models\Event;
+use App\Models\EventAttendee;
+use App\Models\Faction;
+use App\Models\Game;
+use App\Models\Round;
+use App\Models\User;
+
+test('it returns game detail with attendees, scores and army lists', function () {
+    $event = Event::factory()->active()->create();
+    $round = Round::factory()->for($event)->create(['number' => 1]);
+
+    $faction = Faction::factory()->create(['name' => 'Necrons']);
+    $user1 = User::factory()->create(['name' => 'Alice']);
+    $user2 = User::factory()->create(['name' => 'Bob']);
+
+    $attendee1 = EventAttendee::factory()->for($event)->for($user1)->for($faction)->create(['army_list' => '2000pts Necrons']);
+    $attendee2 = EventAttendee::factory()->for($event)->for($user2)->create(['army_list' => '2000pts Tyranids']);
+
+    $game = Game::factory()->for($round)->create(['table_number' => 3]);
+    $game->attendees()->attach($attendee1, ['score' => 85]);
+    $game->attendees()->attach($attendee2, ['score' => 70]);
+
+    $response = $this->getJson(route('events.games.show', ['event' => $event->slug, 'game' => $game->id]))
+        ->assertSuccessful();
+
+    expect($response->json('data.id'))->toBe($game->id)
+        ->and($response->json('data.table_number'))->toBe(3)
+        ->and($response->json('data.is_bye'))->toBeFalse()
+        ->and($response->json('data.round.number'))->toBe(1)
+        ->and($response->json('data.attendees'))->toHaveCount(2)
+        ->and($response->json('data.attendees.0.user.name'))->toBe('Alice')
+        ->and($response->json('data.attendees.0.faction.name'))->toBe('Necrons')
+        ->and($response->json('data.attendees.0.army_list'))->toBe('2000pts Necrons')
+        ->and($response->json('data.attendees.0.score'))->toBe(85);
+});
+
+test('it validates game belongs to event through round', function () {
+    $event = Event::factory()->active()->create();
+    $otherEvent = Event::factory()->active()->create();
+    $round = Round::factory()->for($otherEvent)->create();
+    $game = Game::factory()->for($round)->create();
+
+    $this->getJson(route('events.games.show', ['event' => $event->slug, 'game' => $game->id]))
+        ->assertNotFound();
+});
+
+test('it returns 404 for non-publicly-visible events', function (string $state) {
+    $event = Event::factory()->{$state}()->create();
+    $round = Round::factory()->for($event)->create();
+    $game = Game::factory()->for($round)->create();
+
+    $this->getJson(route('events.games.show', ['event' => $event->slug, 'game' => $game->id]))
+        ->assertNotFound();
+})->with(['draft', 'cancelled']);
+
+test('bye game with single attendee', function () {
+    $event = Event::factory()->active()->create();
+    $round = Round::factory()->for($event)->create();
+    $attendee = EventAttendee::factory()->for($event)->create();
+
+    $game = Game::factory()->for($round)->bye()->create(['table_number' => null]);
+    $game->attendees()->attach($attendee, ['score' => 20]);
+
+    $response = $this->getJson(route('events.games.show', ['event' => $event->slug, 'game' => $game->id]))
+        ->assertSuccessful();
+
+    expect($response->json('data.is_bye'))->toBeTrue()
+        ->and($response->json('data.table_number'))->toBeNull()
+        ->and($response->json('data.attendees'))->toHaveCount(1);
+});
+
+test('multiplayer game with more than two attendees', function () {
+    $event = Event::factory()->active()->create();
+    $round = Round::factory()->for($event)->create();
+
+    $game = Game::factory()->for($round)->create(['table_number' => 5]);
+
+    foreach (['Alice', 'Bob', 'Charlie', 'Diana'] as $name) {
+        $attendee = EventAttendee::factory()->for($event)
+            ->for(User::factory()->create(['name' => $name]))
+            ->create();
+        $game->attendees()->attach($attendee, ['score' => fake()->numberBetween(0, 100)]);
+    }
+
+    $response = $this->getJson(route('events.games.show', ['event' => $event->slug, 'game' => $game->id]))
+        ->assertSuccessful();
+
+    expect($response->json('data.attendees'))->toHaveCount(4);
+});
+
+test('it is a public endpoint requiring no auth', function () {
+    $event = Event::factory()->active()->create();
+    $round = Round::factory()->for($event)->create();
+    $game = Game::factory()->for($round)->create();
+
+    $this->getJson(route('events.games.show', ['event' => $event->slug, 'game' => $game->id]))
+        ->assertSuccessful();
+});

--- a/tests/Feature/Events/ShowEventRoundTest.php
+++ b/tests/Feature/Events/ShowEventRoundTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use App\Models\Event;
+use App\Models\EventAttendee;
+use App\Models\Faction;
+use App\Models\Game;
+use App\Models\Round;
+use App\Models\User;
+
+test('it returns round detail with games ordered by table number', function () {
+    $event = Event::factory()->active()->create();
+    $round = Round::factory()->for($event)->create(['number' => 1, 'name' => 'Round One']);
+
+    $faction = Faction::factory()->create(['name' => 'Space Marines']);
+    $user1 = User::factory()->create(['name' => 'Alice']);
+    $user2 = User::factory()->create(['name' => 'Bob']);
+
+    $attendee1 = EventAttendee::factory()->for($event)->for($user1)->for($faction)->create();
+    $attendee2 = EventAttendee::factory()->for($event)->for($user2)->create();
+
+    $game2 = Game::factory()->for($round)->create(['table_number' => 2]);
+    $game1 = Game::factory()->for($round)->create(['table_number' => 1]);
+
+    $game1->attendees()->attach($attendee1, ['score' => 85]);
+    $game1->attendees()->attach($attendee2, ['score' => 70]);
+    $game2->attendees()->attach($attendee1, ['score' => 90]);
+
+    $response = $this->getJson(route('events.rounds.show', ['event' => $event->slug, 'round' => $round->id]))
+        ->assertSuccessful();
+
+    expect($response->json('data.id'))->toBe($round->id)
+        ->and($response->json('data.number'))->toBe(1)
+        ->and($response->json('data.name'))->toBe('Round One')
+        ->and($response->json('data.games'))->toHaveCount(2);
+
+    $firstGame = $response->json('data.games.0');
+    expect($firstGame['table_number'])->toBe(1)
+        ->and($firstGame['is_bye'])->toBeFalse()
+        ->and($firstGame['attendees'])->toHaveCount(2)
+        ->and($firstGame['attendees'][0]['user']['name'])->toBe('Alice')
+        ->and($firstGame['attendees'][0]['faction']['name'])->toBe('Space Marines')
+        ->and($firstGame['attendees'][0]['score'])->toBe(85);
+});
+
+test('it returns 404 if round does not belong to event', function () {
+    $event = Event::factory()->active()->create();
+    $otherEvent = Event::factory()->active()->create();
+    $round = Round::factory()->for($otherEvent)->create();
+
+    $this->getJson(route('events.rounds.show', ['event' => $event->slug, 'round' => $round->id]))
+        ->assertNotFound();
+});
+
+test('it returns 404 for non-publicly-visible events', function (string $state) {
+    $event = Event::factory()->{$state}()->create();
+    $round = Round::factory()->for($event)->create();
+
+    $this->getJson(route('events.rounds.show', ['event' => $event->slug, 'round' => $round->id]))
+        ->assertNotFound();
+})->with(['draft', 'cancelled']);
+
+test('it returns 404 for published events (no rounds visible)', function () {
+    $event = Event::factory()->published()->create();
+    $round = Round::factory()->for($event)->create();
+
+    $this->getJson(route('events.rounds.show', ['event' => $event->slug, 'round' => $round->id]))
+        ->assertNotFound();
+});

--- a/tests/Feature/Events/ShowEventTest.php
+++ b/tests/Feature/Events/ShowEventTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use App\Models\Event;
+use App\Models\EventDocument;
+
+test('it returns a published event by slug', function () {
+    $event = Event::factory()->published()->create(['slug' => 'londongt-2026']);
+
+    $this->getJson(route('events.show', $event))
+        ->assertSuccessful()
+        ->assertJsonPath('data.slug', 'londongt-2026')
+        ->assertJsonPath('data.status', 'published');
+});
+
+test('it is a public endpoint requiring no auth', function () {
+    $event = Event::factory()->active()->create();
+
+    $this->getJson(route('events.show', $event))->assertSuccessful();
+});
+
+test('it returns 404 for a draft event', function () {
+    $event = Event::factory()->draft()->create();
+
+    $this->getJson(route('events.show', $event))->assertNotFound();
+});
+
+test('it returns 404 for a cancelled event', function () {
+    $event = Event::factory()->cancelled()->create();
+
+    $this->getJson(route('events.show', $event))->assertNotFound();
+});
+
+test('it returns 404 for a non-existent slug', function () {
+    $this->getJson(route('events.show', 'does-not-exist'))->assertNotFound();
+});
+
+test('it includes documents in the detail response', function () {
+    $event = Event::factory()->published()->create();
+    EventDocument::factory()->count(2)->for($event)->create();
+
+    $this->getJson(route('events.show', $event))
+        ->assertSuccessful()
+        ->assertJsonCount(2, 'data.documents');
+});
+
+test('it includes game system and venue details', function () {
+    $event = Event::factory()->published()->create([
+        'venue_name' => 'Example Hall',
+        'venue_city' => 'London',
+    ]);
+
+    $this->getJson(route('events.show', $event))
+        ->assertSuccessful()
+        ->assertJsonPath('data.venue.name', 'Example Hall')
+        ->assertJsonPath('data.venue.city', 'London')
+        ->assertJsonPath('data.game_system.id', $event->game_system_id);
+});

--- a/tests/Feature/Seeders/EventSeederTest.php
+++ b/tests/Feature/Seeders/EventSeederTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use App\Enums\EventStatus;
+use App\Models\Event;
+use App\Models\GameScore;
+use Database\Seeders\EventSeeder;
+
+test('it runs without errors', function () {
+    $this->seed(EventSeeder::class);
+
+    expect(Event::count())->toBeGreaterThanOrEqual(5);
+});
+
+test('it creates events across all statuses', function () {
+    $this->seed(EventSeeder::class);
+
+    foreach (EventStatus::cases() as $status) {
+        expect(Event::where('status', $status)->exists())
+            ->toBeTrue("Missing event with status: {$status->value}");
+    }
+});
+
+test('active event has attendees, rounds, games, and scores', function () {
+    $this->seed(EventSeeder::class);
+
+    $event = Event::where('status', EventStatus::Active)->first();
+
+    expect($event->attendees()->count())->toBe(16)
+        ->and($event->rounds()->count())->toBe(3)
+        ->and($event->rounds()->first()->games()->count())->toBeGreaterThan(0)
+        ->and(GameScore::query()
+            ->whereHas('game', fn ($q) => $q->whereHas('round', fn ($q) => $q->where('event_id', $event->id)))
+            ->count()
+        )->toBeGreaterThan(0)
+        ->and($event->standings()->count())->toBe(16);
+});
+
+test('completed event has full standings for all attendees', function () {
+    $this->seed(EventSeeder::class);
+
+    $event = Event::where('status', EventStatus::Completed)->first();
+    $attendeeCount = $event->attendees()->count();
+
+    expect($attendeeCount)->toBeGreaterThan(0)
+        ->and($event->standings()->count())->toBe($attendeeCount)
+        ->and($event->standings()->first()->scores()->count())->toBe(2);
+});
+
+test('gallery endpoint returns photos for seeded events', function () {
+    $this->seed(EventSeeder::class);
+
+    $event = Event::where('status', EventStatus::Active)->first();
+
+    $this->getJson(route('events.gallery.index', ['event' => $event->slug]))
+        ->assertSuccessful()
+        ->assertJsonStructure(['data'])
+        ->assertJsonPath('data.0.reactions_count', fn ($v) => $v >= 0);
+});
+
+test('event endpoints return meaningful data after seeding', function () {
+    $this->seed(EventSeeder::class);
+
+    $event = Event::where('status', EventStatus::Active)->first();
+
+    $this->getJson(route('events.show', $event))
+        ->assertSuccessful()
+        ->assertJsonPath('data.documents', fn ($docs) => count($docs) >= 1);
+
+    $this->getJson(route('events.updates.index', ['event' => $event->slug]))
+        ->assertSuccessful()
+        ->assertJsonPath('data', fn ($updates) => count($updates) >= 1);
+
+    $this->getJson(route('events.attendees.index', ['event' => $event->slug]))
+        ->assertSuccessful()
+        ->assertJsonPath('data', fn ($attendees) => count($attendees) >= 1);
+
+    $this->getJson(route('events.standings.index', ['event' => $event->slug]))
+        ->assertSuccessful()
+        ->assertJsonPath('data', fn ($standings) => count($standings) >= 1);
+});


### PR DESCRIPTION
This pull request introduces a comprehensive public API for tournament and event management, along with the foundational data models and infrastructure to support it.

The new API provides endpoints for:
- Listing and displaying detailed information for events, attendees, rounds, games, standings, updates, and gallery photos.
- Robust filtering, searching, and sorting capabilities for event listings, attendees, and standings.
- Visibility checks ensuring only publicly accessible events and their relevant data are exposed.
- Detailed attendee views now include custom field responses (with type-aware value interpretation) and game history.
- Round and game details support various game formats, including multiplayer and bye games.
- Event updates feature pinning and attachment support.
- Event gallery includes reaction data (counts, and `has_reacted` for authenticated users).

To support these features, the PR also includes:
- A new `Events` domain with dedicated models (`Event`, `EventAttendee`, `Round`, `Game`, `EventStanding`, `EventUpdate`, `Club`, `GameSystem`, `Faction`, etc.), their respective migrations, factories, and API resources.
- New Enums (`CustomFieldType`, `EventStatus`, `PairingFormat`, `RoundStatus`, `SortDirection`) for clear type definition and business logic.
- Integration of new event-related models with existing `User` and `Photo` models.
- An extensive `EventSeeder` to populate the database with realistic demo event data across all statuses (draft, published, active, completed, cancelled), facilitating development and testing.