### PR TITLE
Extracts Conversation List Query and Unifies Resource

### DIFF
--- a/app/Http/Controllers/Conversations/ListConversationsController.php
+++ b/app/Http/Controllers/Conversations/ListConversationsController.php
@@ -7,10 +7,8 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Conversations\ListConversationsRequest;
 use App\Http\Resources\Conversations\ConversationResource;
 use App\Models\Conversation;
-use App\Models\Message;
 use App\Queries\ConversationListQuery;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
-use Illuminate\Support\Facades\DB;
 use Knuckles\Scribe\Attributes\Endpoint;
 use Knuckles\Scribe\Attributes\Group;
 use Knuckles\Scribe\Attributes\ResponseFromApiResource;
@@ -18,41 +16,14 @@ use Knuckles\Scribe\Attributes\ResponseFromApiResource;
 #[Group('Conversations', 'APIs for Conversations')]
 class ListConversationsController extends Controller
 {
-    private const EPOCH = '1970-01-01 00:00:00';
-
     #[Endpoint('List Conversations', 'List the authenticated user\'s conversations.')]
     #[ResponseFromApiResource(ConversationResource::class, model: Conversation::class, paginate: 15)]
     public function __invoke(ListConversationsRequest $request): AnonymousResourceCollection
     {
-        $userId = $request->user()->id;
         $tab = ConversationTab::tryFrom($request->validated('tab', '')) ?? ConversationTab::Primary;
 
-        $lastReadAt = DB::table('conversation_user')
-            ->whereColumn('conversation_user.conversation_id', 'conversations.id')
-            ->where('conversation_user.user_id', $userId)
-            ->select('last_read_at')
-            ->limit(1);
-
-        $conversations = ConversationListQuery::forUser($userId)
+        $conversations = ConversationListQuery::forUser($request->user()->id)
             ->tab($tab)
-            ->toQuery()
-            ->with(['users', 'latestMessage'])
-            ->addSelect([
-                'latest_message_at' => Message::query()
-                    ->whereColumn('conversation_id', 'conversations.id')
-                    ->latest()
-                    ->select('created_at')
-                    ->limit(1),
-                'unread_count' => Message::query()
-                    ->selectRaw('count(*)')
-                    ->whereColumn('messages.conversation_id', 'conversations.id')
-                    ->where('messages.user_id', '!=', $userId)
-                    ->where('messages.created_at', '>', DB::raw(
-                        'coalesce(('.$lastReadAt->toSql().'), ?)'
-                    ))
-                    ->addBinding([...$lastReadAt->getBindings(), self::EPOCH]),
-            ])
-            ->orderByDesc('latest_message_at')
             ->paginate();
 
         return ConversationResource::collection($conversations);

--- a/app/Http/Controllers/Conversations/ListConversationsController.php
+++ b/app/Http/Controllers/Conversations/ListConversationsController.php
@@ -8,6 +8,7 @@ use App\Http\Requests\Conversations\ListConversationsRequest;
 use App\Http\Resources\Conversations\ConversationResource;
 use App\Models\Conversation;
 use App\Models\Message;
+use App\Queries\ConversationListQuery;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Support\Facades\DB;
 use Knuckles\Scribe\Attributes\Endpoint;
@@ -32,8 +33,9 @@ class ListConversationsController extends Controller
             ->select('last_read_at')
             ->limit(1);
 
-        $conversations = Conversation::query()
-            ->forTab($tab, $userId)
+        $conversations = ConversationListQuery::forUser($userId)
+            ->tab($tab)
+            ->toQuery()
             ->with(['users', 'latestMessage'])
             ->addSelect([
                 'latest_message_at' => Message::query()

--- a/app/Http/Resources/Conversations/ConversationResource.php
+++ b/app/Http/Resources/Conversations/ConversationResource.php
@@ -27,8 +27,7 @@ class ConversationResource extends JsonResource
             'id' => $this->id,
             'is_group' => $this->is_group,
             'name' => $this->name,
-            'participant' => ! $this->is_group ? $otherUsers->first()?->only('id', 'public_name', 'username') : null,
-            'participants' => $this->is_group ? $otherUsers->map->only('id', 'public_name', 'username')->values() : null,
+            'participants' => $otherUsers->map->only('id', 'public_name', 'username')->values()->all(),
             'latest_message' => $this->whenLoaded('latestMessage', fn () => $this->latestMessage
                 ? MessageResource::make($this->latestMessage)
                 : null

--- a/app/Models/Conversation.php
+++ b/app/Models/Conversation.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-use App\Enums\ConversationTab;
 use Database\Factories\ConversationFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
@@ -27,16 +26,10 @@ use Illuminate\Support\Carbon;
  * @property-read Collection<int, User> $users
  * @property-read int|null $users_count
  *
- * @method static Builder<static>|Conversation archivedForUser(int $userId)
- * @method static Builder<static>|Conversation eventsForUser(int $userId)
  * @method static \Database\Factories\ConversationFactory factory($count = null, $state = [])
- * @method static Builder<static>|Conversation forTab(\App\Enums\ConversationTab $tab, int $userId)
- * @method static Builder<static>|Conversation forUser(int $userId)
  * @method static Builder<static>|Conversation newModelQuery()
  * @method static Builder<static>|Conversation newQuery()
- * @method static Builder<static>|Conversation primaryForUser(int $userId)
  * @method static Builder<static>|Conversation query()
- * @method static Builder<static>|Conversation requestsForUser(int $userId)
  * @method static Builder<static>|Conversation whereCreatedAt($value)
  * @method static Builder<static>|Conversation whereEventId($value)
  * @method static Builder<static>|Conversation whereId($value)
@@ -99,103 +92,6 @@ class Conversation extends Model
     public function latestMessage(): HasOne
     {
         return $this->hasOne(Message::class)->latestOfMany();
-    }
-
-    /**
-     * @param  Builder<self>  $query
-     * @return Builder<self>
-     */
-    public function scopeForTab(Builder $query, ConversationTab $tab, int $userId): Builder
-    {
-        return match ($tab) {
-            ConversationTab::Primary => $query->primaryForUser($userId),
-            ConversationTab::Events => $query->eventsForUser($userId),
-            ConversationTab::Requests => $query->requestsForUser($userId),
-            ConversationTab::Archived => $query->archivedForUser($userId),
-        };
-    }
-
-    /**
-     * @param  Builder<self>  $query
-     * @return Builder<self>
-     */
-    public function scopeForUser(Builder $query, int $userId): Builder
-    {
-        return $query->whereHas('users', function (Builder $q) use ($userId) {
-            $q->where('conversation_user.user_id', $userId)
-                ->whereNull('conversation_user.deleted_at')
-                ->whereNull('conversation_user.archived_at');
-        });
-    }
-
-    /**
-     * @param  Builder<self>  $query
-     * @return Builder<self>
-     */
-    public function scopePrimaryForUser(Builder $query, int $userId): Builder
-    {
-        return $query->forUser($userId)
-            ->whereNull('event_id')
-            ->where(function (Builder $q) use ($userId) {
-                $q->where('is_group', true)
-                    ->orWhereRaw(self::firstMessageSenderSql('='), [$userId])
-                    ->orWhereHas('users', self::otherUserFollowedBy($userId));
-            });
-    }
-
-    /**
-     * @param  Builder<self>  $query
-     * @return Builder<self>
-     */
-    public function scopeEventsForUser(Builder $query, int $userId): Builder
-    {
-        return $query->forUser($userId)->whereNotNull('event_id');
-    }
-
-    /**
-     * @param  Builder<self>  $query
-     * @return Builder<self>
-     */
-    public function scopeRequestsForUser(Builder $query, int $userId): Builder
-    {
-        return $query->forUser($userId)
-            ->whereNull('event_id')
-            ->where('is_group', false)
-            ->whereRaw(self::firstMessageSenderSql('!='), [$userId])
-            ->whereDoesntHave('users', self::otherUserFollowedBy($userId));
-    }
-
-    /**
-     * @param  Builder<self>  $query
-     * @return Builder<self>
-     */
-    public function scopeArchivedForUser(Builder $query, int $userId): Builder
-    {
-        return $query->whereHas('users', function (Builder $q) use ($userId) {
-            $q->where('conversation_user.user_id', $userId)
-                ->whereNull('conversation_user.deleted_at')
-                ->whereNotNull('conversation_user.archived_at');
-        });
-    }
-
-    /**
-     * @return \Closure(Builder): void
-     */
-    private static function otherUserFollowedBy(int $userId): \Closure
-    {
-        return function (Builder $q) use ($userId) {
-            $q->where('conversation_user.user_id', '!=', $userId)
-                ->whereIn('conversation_user.user_id', function ($sub) use ($userId) {
-                    $sub->select('following_id')
-                        ->from('follows')
-                        ->where('follower_id', $userId);
-                });
-        };
-    }
-
-    private static function firstMessageSenderSql(string $operator): string
-    {
-        return "(select user_id from messages where messages.conversation_id = conversations.id order by created_at asc limit 1) {$operator} ?";
     }
 
     public static function findBetween(int $userA, int $userB): ?self

--- a/app/Queries/ConversationListQuery.php
+++ b/app/Queries/ConversationListQuery.php
@@ -69,7 +69,7 @@ class ConversationListQuery
             ConversationTab::Primary => $this->applyPrimary($query),
             ConversationTab::Events => $this->applyEvents($query),
             ConversationTab::Requests => $this->applyRequests($query),
-            ConversationTab::Archived => $this->applyArchived(),
+            ConversationTab::Archived => $this->applyArchived($query),
         };
     }
 
@@ -135,9 +135,10 @@ class ConversationListQuery
     }
 
     /**
+     * @param  Builder<Conversation>  $query
      * @return Builder<Conversation>
      */
-    private function applyArchived(): Builder
+    private function applyArchived(Builder $query): Builder
     {
         return Conversation::query()
             ->whereHas('users', function (Builder $q) {

--- a/app/Queries/ConversationListQuery.php
+++ b/app/Queries/ConversationListQuery.php
@@ -14,7 +14,7 @@ class ConversationListQuery
 {
     private const EPOCH = '1970-01-01 00:00:00';
 
-    private ?ConversationTab $tab = null;
+    private ConversationTab $tab;
 
     private function __construct(private int $userId) {}
 
@@ -70,7 +70,6 @@ class ConversationListQuery
             ConversationTab::Events => $this->applyEvents($query),
             ConversationTab::Requests => $this->applyRequests($query),
             ConversationTab::Archived => $this->applyArchived(),
-            default => $query,
         };
     }
 

--- a/app/Queries/ConversationListQuery.php
+++ b/app/Queries/ConversationListQuery.php
@@ -6,11 +6,14 @@ use App\Enums\ConversationTab;
 use App\Models\Conversation;
 use App\Models\Message;
 use Illuminate\Contracts\Database\Query\Expression;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\DB;
 
 class ConversationListQuery
 {
+    private const EPOCH = '1970-01-01 00:00:00';
+
     private ?ConversationTab $tab = null;
 
     private function __construct(private int $userId) {}
@@ -31,6 +34,34 @@ class ConversationListQuery
      * @return Builder<Conversation>
      */
     public function toQuery(): Builder
+    {
+        $query = $this->applyTab();
+
+        return $query
+            ->with(['users', 'latestMessage'])
+            ->addSelect([
+                'latest_message_at' => Message::query()
+                    ->whereColumn('conversation_id', 'conversations.id')
+                    ->latest()
+                    ->select('created_at')
+                    ->limit(1),
+                'unread_count' => $this->unreadCountSubquery(),
+            ])
+            ->orderByDesc('latest_message_at');
+    }
+
+    /**
+     * @return LengthAwarePaginator<int, Conversation>
+     */
+    public function paginate(): LengthAwarePaginator
+    {
+        return $this->toQuery()->paginate();
+    }
+
+    /**
+     * @return Builder<Conversation>
+     */
+    private function applyTab(): Builder
     {
         $query = $this->baseQuery();
 
@@ -115,6 +146,27 @@ class ConversationListQuery
                     ->whereNull('conversation_user.deleted_at')
                     ->whereNotNull('conversation_user.archived_at');
             });
+    }
+
+    /**
+     * @return Builder<Message>
+     */
+    private function unreadCountSubquery(): Builder
+    {
+        $lastReadAt = DB::table('conversation_user')
+            ->whereColumn('conversation_user.conversation_id', 'conversations.id')
+            ->where('conversation_user.user_id', $this->userId)
+            ->select('last_read_at')
+            ->limit(1);
+
+        return Message::query()
+            ->selectRaw('count(*)')
+            ->whereColumn('messages.conversation_id', 'conversations.id')
+            ->where('messages.user_id', '!=', $this->userId)
+            ->where('messages.created_at', '>', DB::raw(
+                'coalesce(('.$lastReadAt->toSql().'), ?)'
+            ))
+            ->addBinding([...$lastReadAt->getBindings(), self::EPOCH]);
     }
 
     private function otherUserFollowedByAuthUser(): \Closure

--- a/app/Queries/ConversationListQuery.php
+++ b/app/Queries/ConversationListQuery.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Queries;
+
+use App\Enums\ConversationTab;
+use App\Models\Conversation;
+use App\Models\Message;
+use Illuminate\Contracts\Database\Query\Expression;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\DB;
+
+class ConversationListQuery
+{
+    private ?ConversationTab $tab = null;
+
+    private function __construct(private int $userId) {}
+
+    public static function forUser(int $userId): self
+    {
+        return new self($userId);
+    }
+
+    public function tab(ConversationTab $tab): self
+    {
+        $this->tab = $tab;
+
+        return $this;
+    }
+
+    /**
+     * @return Builder<Conversation>
+     */
+    public function toQuery(): Builder
+    {
+        $query = $this->baseQuery();
+
+        return match ($this->tab) {
+            ConversationTab::Primary => $this->applyPrimary($query),
+            ConversationTab::Events => $this->applyEvents($query),
+            ConversationTab::Requests => $this->applyRequests($query),
+            ConversationTab::Archived => $this->applyArchived(),
+            default => $query,
+        };
+    }
+
+    /**
+     * @return Builder<Conversation>
+     */
+    private function baseQuery(): Builder
+    {
+        return Conversation::query()
+            ->whereHas('users', function (Builder $q) {
+                $q->where('conversation_user.user_id', $this->userId)
+                    ->whereNull('conversation_user.deleted_at')
+                    ->whereNull('conversation_user.archived_at');
+            });
+    }
+
+    /**
+     * @param  Builder<Conversation>  $query
+     * @return Builder<Conversation>
+     */
+    private function applyPrimary(Builder $query): Builder
+    {
+        return $query
+            ->whereNull('event_id')
+            ->where(function (Builder $q) {
+                $q->where('is_group', true)
+                    ->orWhere($this->firstMessageSender(), $this->userId)
+                    ->orWhereHas('users', $this->otherUserFollowedByAuthUser());
+            });
+    }
+
+    private function firstMessageSender(): Expression
+    {
+        $subquery = Message::query()
+            ->whereColumn('messages.conversation_id', 'conversations.id')
+            ->oldest()
+            ->select('user_id')
+            ->limit(1);
+
+        return DB::raw("({$subquery->toSql()})");
+    }
+
+    /**
+     * @param  Builder<Conversation>  $query
+     * @return Builder<Conversation>
+     */
+    private function applyEvents(Builder $query): Builder
+    {
+        return $query->whereNotNull('event_id');
+    }
+
+    /**
+     * @param  Builder<Conversation>  $query
+     * @return Builder<Conversation>
+     */
+    private function applyRequests(Builder $query): Builder
+    {
+        return $query
+            ->whereNull('event_id')
+            ->where('is_group', false)
+            ->where($this->firstMessageSender(), '!=', $this->userId)
+            ->whereDoesntHave('users', $this->otherUserFollowedByAuthUser());
+    }
+
+    /**
+     * @return Builder<Conversation>
+     */
+    private function applyArchived(): Builder
+    {
+        return Conversation::query()
+            ->whereHas('users', function (Builder $q) {
+                $q->where('conversation_user.user_id', $this->userId)
+                    ->whereNull('conversation_user.deleted_at')
+                    ->whereNotNull('conversation_user.archived_at');
+            });
+    }
+
+    private function otherUserFollowedByAuthUser(): \Closure
+    {
+        return function (Builder $q) {
+            $q->where('conversation_user.user_id', '!=', $this->userId)
+                ->whereIn('conversation_user.user_id', function ($sub) {
+                    $sub->select('following_id')
+                        ->from('follows')
+                        ->where('follower_id', $this->userId);
+                });
+        };
+    }
+}

--- a/app/Queries/ConversationListQuery.php
+++ b/app/Queries/ConversationListQuery.php
@@ -109,7 +109,7 @@ class ConversationListQuery
             ->select('user_id')
             ->limit(1);
 
-        return DB::raw("({$subquery->toSql()})");
+        return DB::raw("({$subquery->toRawSql()})");
     }
 
     /**

--- a/tests/Feature/Conversations/ListConversationsTest.php
+++ b/tests/Feature/Conversations/ListConversationsTest.php
@@ -75,7 +75,7 @@ test('it includes participant and latest message', function () {
         ->assertSuccessful();
 
     $data = $response->json('data.0');
-    expect($data['participant']['id'])->toBe($otherUser->id)
+    expect($data['participants'][0]['id'])->toBe($otherUser->id)
         ->and($data['latest_message']['body'])->toBe('Hi');
 });
 

--- a/tests/Feature/Conversations/StartConversationTest.php
+++ b/tests/Feature/Conversations/StartConversationTest.php
@@ -19,7 +19,7 @@ test('it creates a conversation and returns resource', function () {
 
     $data = $response->json('data');
 
-    expect($data['participant']['id'])->toBe($recipient->id)
+    expect($data['participants'][0]['id'])->toBe($recipient->id)
         ->and($data['latest_message']['body'])->toBe('Hello there!');
 
     $this->assertDatabaseCount('conversations', 1);

--- a/tests/Feature/Queries/ConversationListQueryTest.php
+++ b/tests/Feature/Queries/ConversationListQueryTest.php
@@ -5,6 +5,7 @@ use App\Models\Conversation;
 use App\Models\Message;
 use App\Models\User;
 use App\Queries\ConversationListQuery;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 
 test('forUser returns conversations the user participates in', function () {
     $user = User::factory()->create();
@@ -184,4 +185,186 @@ test('archived tab excludes deleted conversations', function () {
     $result = ConversationListQuery::forUser($user->id)->tab(ConversationTab::Archived)->toQuery()->get();
 
     expect($result)->toHaveCount(0);
+});
+
+test('deleted conversations excluded from primary tab', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    $conversation = Conversation::factory()->withUsers($user, $otherUser)->create();
+    Message::factory()->create(['conversation_id' => $conversation->id, 'user_id' => $user->id]);
+    $conversation->users()->updateExistingPivot($user->id, ['deleted_at' => now()]);
+
+    $result = ConversationListQuery::forUser($user->id)->tab(ConversationTab::Primary)->toQuery()->get();
+
+    expect($result)->toHaveCount(0);
+});
+
+test('deleted conversations excluded from events tab', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    $conversation = Conversation::factory()->withUsers($user, $otherUser)->create(['event_id' => 1]);
+    $conversation->users()->updateExistingPivot($user->id, ['deleted_at' => now()]);
+
+    $result = ConversationListQuery::forUser($user->id)->tab(ConversationTab::Events)->toQuery()->get();
+
+    expect($result)->toHaveCount(0);
+});
+
+test('deleted conversations excluded from requests tab', function () {
+    $user = User::factory()->create();
+    $stranger = User::factory()->create();
+
+    $conversation = Conversation::factory()->withUsers($user, $stranger)->create();
+    Message::factory()->create(['conversation_id' => $conversation->id, 'user_id' => $stranger->id]);
+    $conversation->users()->updateExistingPivot($user->id, ['deleted_at' => now()]);
+
+    $result = ConversationListQuery::forUser($user->id)->tab(ConversationTab::Requests)->toQuery()->get();
+
+    expect($result)->toHaveCount(0);
+});
+
+test('unread count is zero when no messages exist', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    Conversation::factory()->withUsers($user, $otherUser)->group('Test')->create();
+
+    $result = ConversationListQuery::forUser($user->id)->tab(ConversationTab::Primary)->toQuery()->first();
+
+    expect((int) $result->unread_count)->toBe(0);
+});
+
+test('unread count is zero when all messages are from auth user', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    $conversation = Conversation::factory()->withUsers($user, $otherUser)->create();
+    Message::factory()->count(3)->create(['conversation_id' => $conversation->id, 'user_id' => $user->id]);
+
+    $result = ConversationListQuery::forUser($user->id)->tab(ConversationTab::Primary)->toQuery()->first();
+
+    expect((int) $result->unread_count)->toBe(0);
+});
+
+test('unread count counts messages from other users', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    $conversation = Conversation::factory()->withUsers($user, $otherUser)->create();
+    Message::factory()->create([
+        'conversation_id' => $conversation->id,
+        'user_id' => $user->id,
+        'created_at' => now()->subMinutes(10),
+    ]);
+    Message::factory()->count(3)->create([
+        'conversation_id' => $conversation->id,
+        'user_id' => $otherUser->id,
+    ]);
+
+    $result = ConversationListQuery::forUser($user->id)->tab(ConversationTab::Primary)->toQuery()->first();
+
+    expect((int) $result->unread_count)->toBe(3);
+});
+
+test('unread count respects last_read_at', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    $conversation = Conversation::factory()->withUsers($user, $otherUser)->create();
+    Message::factory()->create([
+        'conversation_id' => $conversation->id,
+        'user_id' => $user->id,
+        'created_at' => now()->subHours(3),
+    ]);
+    Message::factory()->create([
+        'conversation_id' => $conversation->id,
+        'user_id' => $otherUser->id,
+        'created_at' => now()->subHours(2),
+    ]);
+
+    $conversation->users()->updateExistingPivot($user->id, ['last_read_at' => now()->subHour()]);
+
+    Message::factory()->create([
+        'conversation_id' => $conversation->id,
+        'user_id' => $otherUser->id,
+        'created_at' => now(),
+    ]);
+
+    $result = ConversationListQuery::forUser($user->id)->tab(ConversationTab::Primary)->toQuery()->first();
+
+    expect((int) $result->unread_count)->toBe(1);
+});
+
+test('null last_read_at counts all other-user messages as unread', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    $conversation = Conversation::factory()->withUsers($user, $otherUser)->group('Test')->create();
+    Message::factory()->count(5)->create([
+        'conversation_id' => $conversation->id,
+        'user_id' => $otherUser->id,
+    ]);
+
+    $result = ConversationListQuery::forUser($user->id)->tab(ConversationTab::Primary)->toQuery()->first();
+
+    expect((int) $result->unread_count)->toBe(5);
+});
+
+test('results ordered by latest message descending', function () {
+    $user = User::factory()->create();
+    $userA = User::factory()->create();
+    $userB = User::factory()->create();
+
+    $older = Conversation::factory()->withUsers($user, $userA)->create();
+    Message::factory()->create([
+        'conversation_id' => $older->id,
+        'user_id' => $user->id,
+        'created_at' => now()->subHour(),
+    ]);
+
+    $newer = Conversation::factory()->withUsers($user, $userB)->create();
+    Message::factory()->create([
+        'conversation_id' => $newer->id,
+        'user_id' => $user->id,
+        'created_at' => now(),
+    ]);
+
+    $result = ConversationListQuery::forUser($user->id)->tab(ConversationTab::Primary)->toQuery()->get();
+
+    expect($result[0]->id)->toBe($newer->id)
+        ->and($result[1]->id)->toBe($older->id);
+});
+
+test('paginate returns paginated results', function () {
+    $user = User::factory()->create();
+
+    for ($i = 0; $i < 20; $i++) {
+        $other = User::factory()->create();
+        $conv = Conversation::factory()->withUsers($user, $other)->create();
+        Message::factory()->create(['conversation_id' => $conv->id, 'user_id' => $user->id]);
+    }
+
+    $result = ConversationListQuery::forUser($user->id)->tab(ConversationTab::Primary)->paginate();
+
+    expect($result)->toBeInstanceOf(LengthAwarePaginator::class)
+        ->and($result->total())->toBe(20)
+        ->and($result->count())->toBe(15);
+});
+
+test('conversation moves from requests to primary when user follows participant', function () {
+    $user = User::factory()->create();
+    $stranger = User::factory()->create();
+
+    $conversation = Conversation::factory()->withUsers($user, $stranger)->create();
+    Message::factory()->create(['conversation_id' => $conversation->id, 'user_id' => $stranger->id]);
+
+    expect(ConversationListQuery::forUser($user->id)->tab(ConversationTab::Requests)->toQuery()->get())->toHaveCount(1);
+    expect(ConversationListQuery::forUser($user->id)->tab(ConversationTab::Primary)->toQuery()->get())->toHaveCount(0);
+
+    $user->following()->attach($stranger);
+
+    expect(ConversationListQuery::forUser($user->id)->tab(ConversationTab::Primary)->toQuery()->get())->toHaveCount(1);
+    expect(ConversationListQuery::forUser($user->id)->tab(ConversationTab::Requests)->toQuery()->get())->toHaveCount(0);
 });

--- a/tests/Feature/Queries/ConversationListQueryTest.php
+++ b/tests/Feature/Queries/ConversationListQueryTest.php
@@ -2,6 +2,7 @@
 
 use App\Enums\ConversationTab;
 use App\Models\Conversation;
+use App\Models\Event;
 use App\Models\Message;
 use App\Models\User;
 use App\Queries\ConversationListQuery;
@@ -86,7 +87,7 @@ test('primary tab excludes event conversations', function () {
     $user = User::factory()->create();
     $otherUser = User::factory()->create();
 
-    Conversation::factory()->withUsers($user, $otherUser)->create(['event_id' => 1]);
+    Conversation::factory()->withUsers($user, $otherUser)->create(['event_id' => Event::factory()->create()->id]);
 
     $result = ConversationListQuery::forUser($user->id)->tab(ConversationTab::Primary)->toQuery()->get();
 
@@ -109,7 +110,7 @@ test('events tab returns only event conversations', function () {
     $user = User::factory()->create();
     $otherUser = User::factory()->create();
 
-    $eventConv = Conversation::factory()->withUsers($user, $otherUser)->create(['event_id' => 1]);
+    $eventConv = Conversation::factory()->withUsers($user, $otherUser)->create(['event_id' => Event::factory()->create()->id]);
     Conversation::factory()->withUsers($user, $otherUser)->create();
 
     $result = ConversationListQuery::forUser($user->id)->tab(ConversationTab::Events)->toQuery()->get();
@@ -149,7 +150,7 @@ test('requests tab excludes event conversations', function () {
     $user = User::factory()->create();
     $stranger = User::factory()->create();
 
-    $conversation = Conversation::factory()->withUsers($user, $stranger)->create(['event_id' => 1]);
+    $conversation = Conversation::factory()->withUsers($user, $stranger)->create(['event_id' => Event::factory()->create()->id]);
     Message::factory()->create(['conversation_id' => $conversation->id, 'user_id' => $stranger->id]);
 
     $result = ConversationListQuery::forUser($user->id)->tab(ConversationTab::Requests)->toQuery()->get();
@@ -204,7 +205,7 @@ test('deleted conversations excluded from events tab', function () {
     $user = User::factory()->create();
     $otherUser = User::factory()->create();
 
-    $conversation = Conversation::factory()->withUsers($user, $otherUser)->create(['event_id' => 1]);
+    $conversation = Conversation::factory()->withUsers($user, $otherUser)->create(['event_id' => Event::factory()->create()->id]);
     $conversation->users()->updateExistingPivot($user->id, ['deleted_at' => now()]);
 
     $result = ConversationListQuery::forUser($user->id)->tab(ConversationTab::Events)->toQuery()->get();

--- a/tests/Feature/Queries/ConversationListQueryTest.php
+++ b/tests/Feature/Queries/ConversationListQueryTest.php
@@ -12,10 +12,10 @@ test('forUser returns conversations the user participates in', function () {
     $otherUser = User::factory()->create();
     $stranger = User::factory()->create();
 
-    $conversation = Conversation::factory()->withUsers($user, $otherUser)->create();
-    Conversation::factory()->withUsers($otherUser, $stranger)->create();
+    $conversation = Conversation::factory()->withUsers($user, $otherUser)->group('Test')->create();
+    Conversation::factory()->withUsers($otherUser, $stranger)->group('Other')->create();
 
-    $result = ConversationListQuery::forUser($user->id)->toQuery()->get();
+    $result = ConversationListQuery::forUser($user->id)->tab(ConversationTab::Primary)->toQuery()->get();
 
     expect($result)->toHaveCount(1)
         ->and($result->first()->id)->toBe($conversation->id);
@@ -25,10 +25,10 @@ test('forUser excludes deleted conversations', function () {
     $user = User::factory()->create();
     $otherUser = User::factory()->create();
 
-    $conversation = Conversation::factory()->withUsers($user, $otherUser)->create();
+    $conversation = Conversation::factory()->withUsers($user, $otherUser)->group('Test')->create();
     $conversation->users()->updateExistingPivot($user->id, ['deleted_at' => now()]);
 
-    $result = ConversationListQuery::forUser($user->id)->toQuery()->get();
+    $result = ConversationListQuery::forUser($user->id)->tab(ConversationTab::Primary)->toQuery()->get();
 
     expect($result)->toHaveCount(0);
 });
@@ -37,10 +37,10 @@ test('forUser excludes archived conversations', function () {
     $user = User::factory()->create();
     $otherUser = User::factory()->create();
 
-    $conversation = Conversation::factory()->withUsers($user, $otherUser)->create();
+    $conversation = Conversation::factory()->withUsers($user, $otherUser)->group('Test')->create();
     $conversation->users()->updateExistingPivot($user->id, ['archived_at' => now()]);
 
-    $result = ConversationListQuery::forUser($user->id)->toQuery()->get();
+    $result = ConversationListQuery::forUser($user->id)->tab(ConversationTab::Primary)->toQuery()->get();
 
     expect($result)->toHaveCount(0);
 });

--- a/tests/Feature/Queries/ConversationListQueryTest.php
+++ b/tests/Feature/Queries/ConversationListQueryTest.php
@@ -1,0 +1,187 @@
+<?php
+
+use App\Enums\ConversationTab;
+use App\Models\Conversation;
+use App\Models\Message;
+use App\Models\User;
+use App\Queries\ConversationListQuery;
+
+test('forUser returns conversations the user participates in', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+    $stranger = User::factory()->create();
+
+    $conversation = Conversation::factory()->withUsers($user, $otherUser)->create();
+    Conversation::factory()->withUsers($otherUser, $stranger)->create();
+
+    $result = ConversationListQuery::forUser($user->id)->toQuery()->get();
+
+    expect($result)->toHaveCount(1)
+        ->and($result->first()->id)->toBe($conversation->id);
+});
+
+test('forUser excludes deleted conversations', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    $conversation = Conversation::factory()->withUsers($user, $otherUser)->create();
+    $conversation->users()->updateExistingPivot($user->id, ['deleted_at' => now()]);
+
+    $result = ConversationListQuery::forUser($user->id)->toQuery()->get();
+
+    expect($result)->toHaveCount(0);
+});
+
+test('forUser excludes archived conversations', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    $conversation = Conversation::factory()->withUsers($user, $otherUser)->create();
+    $conversation->users()->updateExistingPivot($user->id, ['archived_at' => now()]);
+
+    $result = ConversationListQuery::forUser($user->id)->toQuery()->get();
+
+    expect($result)->toHaveCount(0);
+});
+
+test('primary tab includes group conversations', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    Conversation::factory()->withUsers($user, $otherUser)->group('Test Group')->create();
+
+    $result = ConversationListQuery::forUser($user->id)->tab(ConversationTab::Primary)->toQuery()->get();
+
+    expect($result)->toHaveCount(1);
+});
+
+test('primary tab includes conversations user started', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    $conversation = Conversation::factory()->withUsers($user, $otherUser)->create();
+    Message::factory()->create(['conversation_id' => $conversation->id, 'user_id' => $user->id]);
+
+    $result = ConversationListQuery::forUser($user->id)->tab(ConversationTab::Primary)->toQuery()->get();
+
+    expect($result)->toHaveCount(1);
+});
+
+test('primary tab includes conversations with followed users', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    $user->following()->attach($otherUser);
+
+    $conversation = Conversation::factory()->withUsers($user, $otherUser)->create();
+    Message::factory()->create(['conversation_id' => $conversation->id, 'user_id' => $otherUser->id]);
+
+    $result = ConversationListQuery::forUser($user->id)->tab(ConversationTab::Primary)->toQuery()->get();
+
+    expect($result)->toHaveCount(1);
+});
+
+test('primary tab excludes event conversations', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    Conversation::factory()->withUsers($user, $otherUser)->create(['event_id' => 1]);
+
+    $result = ConversationListQuery::forUser($user->id)->tab(ConversationTab::Primary)->toQuery()->get();
+
+    expect($result)->toHaveCount(0);
+});
+
+test('primary tab excludes stranger-initiated conversations', function () {
+    $user = User::factory()->create();
+    $stranger = User::factory()->create();
+
+    $conversation = Conversation::factory()->withUsers($user, $stranger)->create();
+    Message::factory()->create(['conversation_id' => $conversation->id, 'user_id' => $stranger->id]);
+
+    $result = ConversationListQuery::forUser($user->id)->tab(ConversationTab::Primary)->toQuery()->get();
+
+    expect($result)->toHaveCount(0);
+});
+
+test('events tab returns only event conversations', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    $eventConv = Conversation::factory()->withUsers($user, $otherUser)->create(['event_id' => 1]);
+    Conversation::factory()->withUsers($user, $otherUser)->create();
+
+    $result = ConversationListQuery::forUser($user->id)->tab(ConversationTab::Events)->toQuery()->get();
+
+    expect($result)->toHaveCount(1)
+        ->and($result->first()->id)->toBe($eventConv->id);
+});
+
+test('requests tab returns stranger-initiated non-event 1-on-1 conversations', function () {
+    $user = User::factory()->create();
+    $stranger = User::factory()->create();
+
+    $conversation = Conversation::factory()->withUsers($user, $stranger)->create();
+    Message::factory()->create(['conversation_id' => $conversation->id, 'user_id' => $stranger->id]);
+
+    $result = ConversationListQuery::forUser($user->id)->tab(ConversationTab::Requests)->toQuery()->get();
+
+    expect($result)->toHaveCount(1)
+        ->and($result->first()->id)->toBe($conversation->id);
+});
+
+test('requests tab excludes followed user conversations', function () {
+    $user = User::factory()->create();
+    $followed = User::factory()->create();
+
+    $user->following()->attach($followed);
+
+    $conversation = Conversation::factory()->withUsers($user, $followed)->create();
+    Message::factory()->create(['conversation_id' => $conversation->id, 'user_id' => $followed->id]);
+
+    $result = ConversationListQuery::forUser($user->id)->tab(ConversationTab::Requests)->toQuery()->get();
+
+    expect($result)->toHaveCount(0);
+});
+
+test('requests tab excludes event conversations', function () {
+    $user = User::factory()->create();
+    $stranger = User::factory()->create();
+
+    $conversation = Conversation::factory()->withUsers($user, $stranger)->create(['event_id' => 1]);
+    Message::factory()->create(['conversation_id' => $conversation->id, 'user_id' => $stranger->id]);
+
+    $result = ConversationListQuery::forUser($user->id)->tab(ConversationTab::Requests)->toQuery()->get();
+
+    expect($result)->toHaveCount(0);
+});
+
+test('archived tab returns archived conversations', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    $conversation = Conversation::factory()->withUsers($user, $otherUser)->create();
+    $conversation->users()->updateExistingPivot($user->id, ['archived_at' => now()]);
+
+    Conversation::factory()->withUsers($user, $otherUser)->create();
+
+    $result = ConversationListQuery::forUser($user->id)->tab(ConversationTab::Archived)->toQuery()->get();
+
+    expect($result)->toHaveCount(1)
+        ->and($result->first()->id)->toBe($conversation->id);
+});
+
+test('archived tab excludes deleted conversations', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    $conversation = Conversation::factory()->withUsers($user, $otherUser)->create();
+    $conversation->users()->updateExistingPivot($user->id, [
+        'archived_at' => now(),
+        'deleted_at' => now(),
+    ]);
+
+    $result = ConversationListQuery::forUser($user->id)->tab(ConversationTab::Archived)->toQuery()->get();
+
+    expect($result)->toHaveCount(0);
+});

--- a/tests/Unit/Resources/ConversationResourceTest.php
+++ b/tests/Unit/Resources/ConversationResourceTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use App\Http\Resources\Conversations\ConversationResource;
+use App\Models\Conversation;
+use App\Models\User;
+use Illuminate\Http\Request;
+
+test('dm conversation returns participants array with one element', function () {
+    $authUser = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    $conversation = Conversation::factory()->withUsers($authUser, $otherUser)->create();
+
+    $request = Request::create('/');
+    $request->setUserResolver(fn () => $authUser);
+
+    $resource = ConversationResource::make($conversation->load('users'))->toArray($request);
+
+    expect($resource['participants'])->toBeArray()
+        ->toHaveCount(1)
+        ->and($resource['participants'][0])->toBe([
+            'id' => $otherUser->id,
+            'public_name' => $otherUser->public_name,
+            'username' => $otherUser->username,
+        ]);
+});
+
+test('group conversation returns participants array with multiple elements', function () {
+    $authUser = User::factory()->create();
+    $memberA = User::factory()->create();
+    $memberB = User::factory()->create();
+
+    $conversation = Conversation::factory()->group('Test Group')->create();
+    $conversation->users()->attach([$authUser->id, $memberA->id, $memberB->id]);
+
+    $request = Request::create('/');
+    $request->setUserResolver(fn () => $authUser);
+
+    $resource = ConversationResource::make($conversation->load('users'))->toArray($request);
+
+    expect($resource['participants'])->toBeArray()
+        ->toHaveCount(2)
+        ->and(collect($resource['participants'])->pluck('id')->all())
+        ->toContain($memberA->id, $memberB->id);
+});
+
+test('response does not contain singular participant key', function () {
+    $authUser = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    $conversation = Conversation::factory()->withUsers($authUser, $otherUser)->create();
+
+    $request = Request::create('/');
+    $request->setUserResolver(fn () => $authUser);
+
+    $resource = ConversationResource::make($conversation->load('users'))->toArray($request);
+
+    expect($resource)->not->toHaveKey('participant');
+});


### PR DESCRIPTION
This refactoring significantly improves the structure and maintainability of conversation listing functionality.

*   **Extracts ConversationListQuery:** Moves complex conversation retrieval logic, including tab filtering, latest message calculations, and unread counts, from the `Conversation` model and `ListConversationsController` into a dedicated `ConversationListQuery` object. This separates concerns, enhances readability, and makes the query logic more testable.
*   **Unifies ConversationResource:** Standardizes the `ConversationResource` to consistently return participants as an array, regardless of whether the conversation is a group or a direct message. This simplifies frontend consumption by removing the conditional `participant` key.
*   **Enhances Test Coverage:** Introduces comprehensive feature tests for `ConversationListQuery` and unit tests for `ConversationResource` to ensure the new implementation works as expected and prevent regressions.